### PR TITLE
Add new Chainhash mode - Quadratic ChainHash

### DIFF
--- a/docs/chainhash_modes.md
+++ b/docs/chainhash_modes.md
@@ -1,11 +1,12 @@
 # Chainhash modes
 
-|CH-Mode|Data block format|Doc|
-|---|---|---|
-|1|0B|Performs a normal chainhash (just repeat the hahsing on the same hash)|
-|2|0-255B S|Performs a chainhash with a constant salt (repeat the hahsing on the same hash + a given salt)|
-|3|8B SN|Performs a chainhash with a count salt (repeat the hahsing on the same hash + a incrementing number)|
-|4|8B SN, 0-247B S|Performs a chainhash with a count and constant salt (repeat the hahsing on the same hash + a incrementing number + a given salt)|
+| CH-Mode |Data block format| Doc                                                                                                                              |
+|---------|---|----------------------------------------------------------------------------------------------------------------------------------|
+| 1       |0B| Performs a normal chainhash (just repeat the hahsing on the same hash)                                                           |
+| 2       |0-255B S| Performs a chainhash with a constant salt (repeat the hahsing on the same hash + a given salt)                                   |
+| 3       |8B SN| Performs a chainhash with a count salt (repeat the hahsing on the same hash + a incrementing number)                             |
+| 4       |8B SN, 0-247B S| Performs a chainhash with a count and constant salt (repeat the hahsing on the same hash + a incrementing number + a given salt) |
+| 5       |8B SN| Performs a chainhash with a quadratic count salt (repeat the hahsing on the same hash + a incrementing quadratic number)         |
 
 
 ## Data block format

--- a/include/pwfunc.h
+++ b/include/pwfunc.h
@@ -23,6 +23,7 @@ public:
     Bytes chainhashWithConstantSalt(const std::string password, int iterations=1, const std::string salt="") const noexcept;    //adds a constant salt each iteration
     Bytes chainhashWithCountSalt(const std::string password, int iterations=1, int salt_start=1) const noexcept;    //adds a salt (number that counts up each iteration)
     Bytes chainhashWithCountAndConstantSalt(const std::string password, int iterations=1, int salt_start=1, const std::string salt="") const noexcept;  //adds a constant and count salt each iteration
+    Bytes chainhashWithQuadraticCountSalt(const std::string password, int iterations=1, int salt_start=1, int a=1, int b=1, int c=1) const noexcept;  //adds a quadratic count salt each iteration
 };
 
 #endif //PWFUNC_H

--- a/src/chainhash_modes.cpp
+++ b/src/chainhash_modes.cpp
@@ -26,6 +26,11 @@ bool ChainHashModes::isChainHashValid(unsigned char const chainhash_mode, unsign
             return false;   //datablock too short
         }
         return true;
+    case 5: //count salt begin needed (8 Bytes for quadratic count salt)
+        if(datablock.getLen() != 8){
+        return false;   //datablock has an invalid length
+        }
+        return true;
     default:
         return false;  //chainhash mode not valid
     }
@@ -41,6 +46,8 @@ Bytes ChainHashModes::performChainHash(unsigned char const chainhash_mode, unsig
         return Bytes();
     case 4: //constant + count salt
         return Bytes();
+    case 5: //Quadratic count salt
+        return Bytes();
     default:
         throw std::invalid_argument("chainhash mode does not exist");
     }
@@ -55,6 +62,8 @@ Bytes ChainHashModes::performChainHash(unsigned char const chainhash_mode, unsig
     case 3: //count salt
         return Bytes();
     case 4: //constant + count salt
+        return Bytes();
+    case 5: //quadratic count salt
         return Bytes();
     default:
         throw std::invalid_argument("chainhash mode does not exist");

--- a/src/pwfunc.cpp
+++ b/src/pwfunc.cpp
@@ -67,3 +67,15 @@ Bytes PwFunc::chainhashWithCountAndConstantSalt(const std::string password, int 
     }
     return ret;
 }
+
+Bytes PwFunc::chainhashWithQuadraticCountSalt(const std::string password, int iterations, int salt_start, int a, int b, int c) const noexcept{
+    Bytes ret = this->hash->hash(password+std::to_string(a*salt_start*salt_start + b*salt_start + c));  //hashes the password with the a*start_salt^2 + b*start_salt + c added
+    for(int i=1; i < iterations; i++){
+    //for iterations - 1 the salt will count up and get hashed. The hash is added to the current hash and is hashed again
+    salt_start++;
+    Bytes hashed_salt = this->hash->hash(std::to_string(a*salt_start*salt_start + b*salt_start + c));
+    ret.addBytes(hashed_salt);
+    ret = this->hash->hash(ret);
+    }
+    return ret;
+}

--- a/tests/pwfunc_unittest.cpp
+++ b/tests/pwfunc_unittest.cpp
@@ -24,6 +24,10 @@ TEST(PWFUNCClass, input_output){
         EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp6.getLen());
         Bytes tmp7 = pwf.chainhashWithCountAndConstantSalt(p, SET_PW_ITERS, 100, gen_random_string(100));
         EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp7.getLen());
+        Bytes tmp8 = pwf.chainhashWithQuadraticCountSalt(p, SET_PW_ITERS);
+        EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp8.getLen());
+        Bytes tmp9 = pwf.chainhashWithQuadraticCountSalt(p, SET_PW_ITERS, 100);
+        EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp9.getLen());
     }
 
     delete hash;
@@ -43,6 +47,8 @@ TEST(PWFUNCClass, concistency){
         EXPECT_EQ(pwf.chainhashWithCountSalt(p, SET_PW_ITERS, 100), pwf.chainhashWithCountSalt(p, SET_PW_ITERS, 100));
         EXPECT_EQ(pwf.chainhashWithCountAndConstantSalt(p, SET_PW_ITERS), pwf.chainhashWithCountAndConstantSalt(p, SET_PW_ITERS));
         EXPECT_EQ(pwf.chainhashWithCountAndConstantSalt(p, SET_PW_ITERS, 100, s), pwf.chainhashWithCountAndConstantSalt(p, SET_PW_ITERS, 100, s));
+        EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(p, SET_PW_ITERS), pwf.chainhashWithCountSalt(p, SET_PW_ITERS));
+        EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(p, SET_PW_ITERS, 100), pwf.chainhashWithCountSalt(p, SET_PW_ITERS, 100));
     }
 
     delete hash;


### PR DESCRIPTION
I changed docs in chainhash_modes.md, add functions in both chainhash_modes and pwfunc. Also created unit test.

Currently I assigned the CH-mode 5 for this new function called "chainhashWithQuadraticCountSalt"

This should partially resolve #3 