### PR TITLE
Complete pwfunc unittests

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -9,12 +9,16 @@ if a functionality is used in different files or scenarios, it should be defined
 #include <iostream>
 #include <vector>
 
+#include "bytes.h"
+
 // checks if a string ends with a string
 bool endsWith(const std::string& fullString, const std::string& ending) noexcept;
 // transforms a u_int64_t into a byte array
 std::vector<unsigned char> LongToCharVec(const u_int64_t a) noexcept;
 // transforms a byte array into a string
 std::string charVecToString(const std::vector<unsigned char> v) noexcept;
+// transforms a string into a byts object
+Bytes stringToBytes(const std::string str) noexcept;
 // gets the byte length of a long number
 unsigned int getLongLen(const u_int64_t num) noexcept;
 

--- a/src/pwfunc.cpp
+++ b/src/pwfunc.cpp
@@ -1,6 +1,7 @@
 #include "pwfunc.h"
 
 #include "settings.h"
+#include "utility.h"
 
 ErrorStruct<bool> PwFunc::isPasswordValid(const std::string password) noexcept {
     // checks the password for illegal format, sets an error if it is not valid
@@ -45,10 +46,9 @@ Bytes PwFunc::chainhash(const std::string password, const u_int64_t iterations) 
 
 Bytes PwFunc::chainhashWithConstantSalt(const std::string password, const u_int64_t iterations, const std::string salt) const noexcept {
     Bytes ret = this->hash->hash(password + salt);  // hashes the password with the salt added
-    Bytes hashed_salt = this->hash->hash(salt);     // hashes the salt
     for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations -1 the salt hash is added to the current hash and the result is hashed again
-        ret.addBytes(hashed_salt);
+        // for iterations -1 the salt is added to the current hash and the result is hashed again
+        ret.addBytes(stringToBytes(salt));
         ret = this->hash->hash(ret);
     }
     return ret;
@@ -57,10 +57,9 @@ Bytes PwFunc::chainhashWithConstantSalt(const std::string password, const u_int6
 Bytes PwFunc::chainhashWithCountSalt(const std::string password, const u_int64_t iterations, u_int64_t salt_start) const noexcept {
     Bytes ret = this->hash->hash(password + std::to_string(salt_start));  // hashes the password with the start salt added
     for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations - 1 the salt will count up and get hashed. The hash is added to the current hash and is hashed again
+        // for iterations - 1 the salt will count up and gets added to the current hash and is hashed again
         salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));
-        ret.addBytes(hashed_salt);
+        ret.addBytes(stringToBytes(std::to_string(salt_start)));
         ret = this->hash->hash(ret);
     }
     return ret;
@@ -68,14 +67,11 @@ Bytes PwFunc::chainhashWithCountSalt(const std::string password, const u_int64_t
 
 Bytes PwFunc::chainhashWithCountAndConstantSalt(const std::string password, const u_int64_t iterations, u_int64_t salt_start, const std::string salt) const noexcept {
     Bytes ret = this->hash->hash(password + salt + std::to_string(salt_start));  // the password is hashed with the salt and the count salt
-    Bytes hashed_constant_salt = this->hash->hash(salt);                         // the constant salt gets hashed
     for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations -1 the count salt will increment and get hashed. Next the constant salt hash gets added to the current hash as well as the count salt hash
+        // for iterations -1 the count salt will increment. The constant salt gets added to the current hash as well as the count salt
         // the result is hashed again
         salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));
-        ret.addBytes(hashed_constant_salt);
-        ret.addBytes(hashed_salt);
+        ret.addBytes(stringToBytes(salt + std::to_string(salt_start)));
         ret = this->hash->hash(ret);
     }
     return ret;
@@ -84,82 +80,63 @@ Bytes PwFunc::chainhashWithCountAndConstantSalt(const std::string password, cons
 Bytes PwFunc::chainhashWithQuadraticCountSalt(const std::string password, const u_int64_t iterations, u_int64_t salt_start, const u_int64_t a, const u_int64_t b, const u_int64_t c) const noexcept {
     Bytes ret = this->hash->hash(password + std::to_string(a * salt_start * salt_start + b * salt_start + c));  // hashes the password with the a*start_salt^2 + b*start_salt + c added
     for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations - 1 the salt will count up and get hashed. The hash is added to the current hash and is hashed again
+        // for iterations - 1 the salt will count up and its quadratic value is added to the current hash and is hashed again
         salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(a * salt_start * salt_start + b * salt_start + c));
-        ret.addBytes(hashed_salt);
+        ret.addBytes(stringToBytes(std::to_string(a * salt_start * salt_start + b * salt_start + c)));
         ret = this->hash->hash(ret);
     }
     return ret;
 }
 
 Bytes PwFunc::chainhash(const Bytes data, const u_int64_t iterations) const noexcept {
-    Bytes ret = this->hash->hash(data);  // hashes the data
-    for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations -1 the hash is hashed again
+    Bytes ret = data;
+    for (u_int64_t i = 0; i < iterations; i++) {
+        // for iterations the hash is hashed again
         ret = this->hash->hash(ret);
     }
     return ret;
 }
 
 Bytes PwFunc::chainhashWithConstantSalt(const Bytes data, const u_int64_t iterations, const std::string salt) const noexcept {
-    Bytes hashed_salt = this->hash->hash(salt);  // hashes the salt
-    Bytes new_data = data;
-    new_data.addBytes(hashed_salt);          // add the salt bytes to the data
-    Bytes ret = this->hash->hash(new_data);  // hashes the data with the salt added
-    for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations -1 the salt hash is added to the current hash and the result is hashed again
-        ret.addBytes(hashed_salt);
+    Bytes ret = data;
+    for (u_int64_t i = 0; i < iterations; i++) {
+        // for iterations the salt is added to the current hash and the result is hashed again
+        ret.addBytes(stringToBytes(salt));
         ret = this->hash->hash(ret);
     }
     return ret;
 }
 
 Bytes PwFunc::chainhashWithCountSalt(const Bytes data, const u_int64_t iterations, u_int64_t salt_start) const noexcept {
-    Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));  // hashes the salt
-    Bytes new_data = data;
-    new_data.addBytes(hashed_salt);          // add the salt bytes to the data
-    Bytes ret = this->hash->hash(new_data);  // hashes the data with the salt added
-    for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations - 1 the salt will count up and get hashed. The hash is added to the current hash and is hashed again
-        salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));
-        ret.addBytes(hashed_salt);
+    Bytes ret = data;
+    for (u_int64_t i = 0; i < iterations; i++) {
+        // for iterations the salt will count up and is added to the current hash and is hashed again
+        ret.addBytes(stringToBytes(std::to_string(salt_start)));
         ret = this->hash->hash(ret);
+        salt_start++;
     }
     return ret;
 }
 
 Bytes PwFunc::chainhashWithCountAndConstantSalt(const Bytes data, const u_int64_t iterations, u_int64_t salt_start, const std::string salt) const noexcept {
-    Bytes hashed_constant_salt = this->hash->hash(salt);               // hashes the constant salt
-    Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));  // hashes the count salt
-    Bytes new_data = data;
-    new_data.addBytes(hashed_constant_salt);  // add the constant salt bytes to the data
-    new_data.addBytes(hashed_salt);           // add the count salt bytes to the data
-    Bytes ret = this->hash->hash(new_data);   // hashes the data with the salt added
-    for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations -1 the count salt will increment and get hashed. Next the constant salt hash gets added to the current hash as well as the count salt hash
+    Bytes ret = data;
+    for (u_int64_t i = 0; i < iterations; i++) {
+        // for iterations the count salt will increment. The constant salt gets added to the current hash as well as the count salt
         // the result is hashed again
-        salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(salt_start));
-        ret.addBytes(hashed_constant_salt);
-        ret.addBytes(hashed_salt);
+        ret.addBytes(stringToBytes(salt + std::to_string(salt_start)));
         ret = this->hash->hash(ret);
+        salt_start++;
     }
     return ret;
 }
 
 Bytes PwFunc::chainhashWithQuadraticCountSalt(const Bytes data, const u_int64_t iterations, u_int64_t salt_start, const u_int64_t a, const u_int64_t b, const u_int64_t c) const noexcept {
-    Bytes hashed_salt = this->hash->hash(std::to_string(a * salt_start * salt_start + b * salt_start + c));  // hashes the quadartic salt
-    Bytes new_data = data;
-    new_data.addBytes(hashed_salt);          // add the salt bytes to the data
-    Bytes ret = this->hash->hash(new_data);  // hashes the data with the salt added
-    for (u_int64_t i = 1; i < iterations; i++) {
-        // for iterations - 1 the salt will count up and get hashed. The hash is added to the current hash and is hashed again
-        salt_start++;
-        Bytes hashed_salt = this->hash->hash(std::to_string(a * salt_start * salt_start + b * salt_start + c));
-        ret.addBytes(hashed_salt);
+    Bytes ret = data;
+    for (u_int64_t i = 0; i < iterations; i++) {
+        // for iterations the salt will count up and its quadratic value is added to the current hash and is hashed again
+        ret.addBytes(stringToBytes(std::to_string(a * salt_start * salt_start + b * salt_start + c)));
         ret = this->hash->hash(ret);
+        salt_start++;
     }
     return ret;
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -36,6 +36,13 @@ std::string charVecToString(const std::vector<unsigned char> v) noexcept {
     return ret;
 }
 
+Bytes stringToBytes(const std::string str) noexcept { 
+    // transforms a string into a Bytes object
+    Bytes ret;
+    ret.setBytes(std::vector<unsigned char>(str.begin(), str.end()));
+    return ret;
+}
+
 unsigned int getLongLen(const u_int64_t num) noexcept {
     // gets the byte length of a long number
     unsigned int ret = 0;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -36,7 +36,7 @@ std::string charVecToString(const std::vector<unsigned char> v) noexcept {
     return ret;
 }
 
-Bytes stringToBytes(const std::string str) noexcept { 
+Bytes stringToBytes(const std::string str) noexcept {
     // transforms a string into a Bytes object
     Bytes ret;
     ret.setBytes(std::vector<unsigned char>(str.begin(), str.end()));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,8 @@ target_link_libraries(pman_test_rng gtest_main)
 target_link_libraries(pman_test_rng ${OPENSSL_LIBRARIES} pthread)
 target_include_directories(pman_test_rng PUBLIC ${INCLUDE_DIR})
 
-add_executable(pman_test_pwfunc main_test.cpp test_utils.cpp pwfunc_unittest.cpp ${SRC_DIR}/pwfunc.cpp ${SRC_DIR}/sha256.cpp ${SRC_DIR}/bytes.cpp ${SRC_DIR}/rng.cpp)
+add_executable(pman_test_pwfunc main_test.cpp test_utils.cpp pwfunc_unittest.cpp ${SRC_DIR}/utility.cpp
+    ${SRC_DIR}/pwfunc.cpp ${SRC_DIR}/sha256.cpp ${SRC_DIR}/bytes.cpp ${SRC_DIR}/rng.cpp)
 target_link_libraries(pman_test_pwfunc gtest_main)
 target_link_libraries(pman_test_pwfunc ${OPENSSL_LIBRARIES} pthread)
 target_include_directories(pman_test_pwfunc PUBLIC ${TEST_INCLUDE_DIR})

--- a/tests/pwfunc_unittest.cpp
+++ b/tests/pwfunc_unittest.cpp
@@ -3,10 +3,10 @@
 #include "gtest/gtest.h"
 #include "rng.h"
 #include "settings.h"
-#include "utility.h"
 #include "sha256.h"
 #include "test_settings.cpp"
 #include "test_utils.h"  //provide gen_random for random strings
+#include "utility.h"
 
 TEST(PWFUNCClass, returnTypes) {
     // check if the return types are correct
@@ -51,13 +51,13 @@ TEST(PWFUNCClass, input_output) {
         rand_b.setBytes(RNG::get_random_bytes(8));
         u_int64_t l5 = toLong(rand_b);
 
-        //create same random password string and Bytes
+        // create same random password string and Bytes
         Bytes passwordbytes;
         std::string password;
         passwordbytes.setBytes(RNG::get_random_bytes(i));
         password = charVecToString(passwordbytes.getBytes());
 
-        //testing chainhashes with string data
+        // testing chainhashes with string data
         Bytes tmp = pwf.chainhash(password, l1);
         EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp.getLen());
         Bytes tmp2 = pwf.chainhashWithConstantSalt(password, l1);
@@ -77,7 +77,7 @@ TEST(PWFUNCClass, input_output) {
         Bytes tmp9 = pwf.chainhashWithQuadraticCountSalt(password, l1, l2, l3, l4, l5);
         EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp9.getLen());
 
-        //testing chainhashes with Bytes data
+        // testing chainhashes with Bytes data
         Bytes tmp10 = pwf.chainhash(passwordbytes, l1);
         EXPECT_EQ(SHA256_DIGEST_LENGTH, tmp10.getLen());
         Bytes tmp12 = pwf.chainhashWithConstantSalt(passwordbytes, l1);
@@ -107,27 +107,27 @@ TEST(PWFUNCClass, consistency) {
     PwFunc pwf = PwFunc(hash);
 
     for (int i = 0; i < TEST_MAX_PW_LEN; i++) {
-        //create same random password string and Bytes
+        // create same random password string and Bytes
         Bytes passwordbytes;
         std::string password;
         passwordbytes.setBytes(RNG::get_random_bytes(i));
         password = charVecToString(passwordbytes.getBytes());
 
-        //create same random salt
+        // create same random salt
         std::string s = gen_random_string(100);
 
         Bytes rand_b;
         rand_b.setBytes(RNG::get_random_bytes(2));
         u_int64_t l1 = toLong(rand_b) / 6;
-        
-        //cap the number of iterations
+
+        // cap the number of iterations
         if (MIN_ITERATIONS > l1) {
             l1 = MIN_ITERATIONS;
         } else if (MAX_ITERATIONS < l1) {
             l1 = TEST_MAX_PW_ITERS;
         }
 
-        //generating random arguments
+        // generating random arguments
         rand_b.setBytes(RNG::get_random_bytes(8));
         u_int64_t l2 = toLong(rand_b);
         rand_b.setBytes(RNG::get_random_bytes(8));
@@ -137,7 +137,7 @@ TEST(PWFUNCClass, consistency) {
         rand_b.setBytes(RNG::get_random_bytes(8));
         u_int64_t l5 = toLong(rand_b);
 
-        //testing chainhashes with string data
+        // testing chainhashes with string data
         EXPECT_EQ(pwf.chainhash(password, l1), pwf.chainhash(password, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(password, l1), pwf.chainhashWithConstantSalt(password, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(password, l1, s), pwf.chainhashWithConstantSalt(password, l1, s));
@@ -147,8 +147,8 @@ TEST(PWFUNCClass, consistency) {
         EXPECT_EQ(pwf.chainhashWithCountAndConstantSalt(password, l1, l2, s), pwf.chainhashWithCountAndConstantSalt(password, l1, l2, s));
         EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(password, l1), pwf.chainhashWithQuadraticCountSalt(password, l1));
         EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(password, l1, l2, l3, l4, l5), pwf.chainhashWithQuadraticCountSalt(password, l1, l2, l3, l4, l5));
-    
-        //testing chainhashes with Bytes data
+
+        // testing chainhashes with Bytes data
         EXPECT_EQ(pwf.chainhash(passwordbytes, l1), pwf.chainhash(passwordbytes, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(passwordbytes, l1), pwf.chainhashWithConstantSalt(passwordbytes, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(passwordbytes, l1, s), pwf.chainhashWithConstantSalt(passwordbytes, l1, s));
@@ -158,8 +158,8 @@ TEST(PWFUNCClass, consistency) {
         EXPECT_EQ(pwf.chainhashWithCountAndConstantSalt(passwordbytes, l1, l2, s), pwf.chainhashWithCountAndConstantSalt(passwordbytes, l1, l2, s));
         EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(passwordbytes, l1), pwf.chainhashWithQuadraticCountSalt(passwordbytes, l1));
         EXPECT_EQ(pwf.chainhashWithQuadraticCountSalt(passwordbytes, l1, l2, l3, l4, l5), pwf.chainhashWithQuadraticCountSalt(passwordbytes, l1, l2, l3, l4, l5));
-    
-        //testing chainhashes with string and Bytes data
+
+        // testing chainhashes with string and Bytes data
         EXPECT_EQ(pwf.chainhash(password, l1), pwf.chainhash(passwordbytes, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(password, l1), pwf.chainhashWithConstantSalt(passwordbytes, l1));
         EXPECT_EQ(pwf.chainhashWithConstantSalt(password, l1, s), pwf.chainhashWithConstantSalt(passwordbytes, l1, s));
@@ -178,13 +178,13 @@ TEST(PWFUNCClass, correctness) {
     // checks if the output is correct
     sha256* hash = new sha256();
     PwFunc pwf = PwFunc(hash);
-    //setting the passwords (string and Bytes) and salt
+    // setting the passwords (string and Bytes) and salt
     std::string password = "Password";
     Bytes passwordbytes;
     passwordbytes.setBytes(std::vector<unsigned char>(password.begin(), password.end()));
     std::string s = "salt";
 
-    //password hash and password hash hash
+    // password hash and password hash hash
     std::string phash = "e7cf3ef4f17c3999a94f2c6f612e8a888e5b1026878e4e19398b23bd38ec221a";
     std::string phashs = "c990daffb01d8091e8af9a91227370cfa6f7d1c44e7ab062940486c57676418c";
 

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -62,7 +62,7 @@ const constexpr double TEST_RNG_BYTE_ENTROPY_ERROR_2BUFFER = 0.04;  // max accep
 //{T<256^2>; N<256^2>}
 const constexpr int TEST_MAX_PW_ITERS = 10000;  // number of iterations for the chainhash functions
 //{S; T<16>}
-const constexpr int TEST_MAX_PW_LEN = 30;  // up to which password length should be tested
+const constexpr int TEST_MAX_PW_LEN = 20;  // up to which password length should be tested
 //+++++++++++++++++dataheader++++++++++++++++++++++++++++++
 //{S; A}
 const constexpr u_int64_t TEST_DH_ITERS = 10000;  // number of dataheaders tested
@@ -86,7 +86,7 @@ const constexpr u_int64_t TEST_DH_CALC_ITERS = 15;  // number of iterations for 
 // const constexpr double TEST_RNG_BYTE_ENTROPY_ERROR_2BUFFER = 0.02;
 
 // const constexpr int TEST_MAX_PW_ITERS = 65000;
-// const constexpr int TEST_MAX_PW_LEN = 30;
+// const constexpr int TEST_MAX_PW_LEN = 20;
 
 // const constexpr u_int64_t TEST_DH_ITERS = 20000;
 // const constexpr u_int64_t TEST_DH_MAX_PW_ITERS = 20000;
@@ -108,7 +108,7 @@ const constexpr u_int64_t TEST_DH_CALC_ITERS = 15;  // number of iterations for 
 // const constexpr double TEST_RNG_BYTE_ENTROPY_ERROR_2BUFFER = 0.01;
 
 // const constexpr u_int64_t TEST_MAX_PW_ITERS = 65000;
-// const constexpr int TEST_MAX_PW_LEN = 30;
+// const constexpr int TEST_MAX_PW_LEN = 20;
 
 // const constexpr u_int64_t TEST_DH_ITERS = 50000;
 // const constexpr u_int64_t TEST_DH_MAX_PW_ITERS = 20000;

--- a/tests/utility_unittest.cpp
+++ b/tests/utility_unittest.cpp
@@ -1,6 +1,9 @@
 #include "utility.h"
 
 #include "gtest/gtest.h"
+#include "rng.h"
+
+//testing the utility functions
 
 TEST(UtilityClass, endswith) {
     std::string s1 = "isdahfaksjdfas asdf asdf sadffsaasdfkoö-.:fp9pfdas ";
@@ -99,4 +102,15 @@ TEST(UtilityClass, getLongLen) {
     EXPECT_EQ(1, getLongLen(l9));
     EXPECT_EQ(5, getLongLen(l10));
     EXPECT_EQ(4, getLongLen(l11));
+}
+
+TEST(UtilityClass, stringToBytes){
+    Bytes b1;
+    for(u_int64_t i = 0; i < 1000; i++){
+        b1.setBytes(RNG::get_random_bytes(10));
+        EXPECT_EQ(b1, stringToBytes(charVecToString(b1.getBytes())));
+    }
+    std::string s1 = "moin";
+    b1.setBytes(std::vector<unsigned char>(s1.begin(), s1.end()));
+    EXPECT_EQ(b1, stringToBytes(s1));
 }

--- a/tests/utility_unittest.cpp
+++ b/tests/utility_unittest.cpp
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 #include "rng.h"
 
-//testing the utility functions
+// testing the utility functions
 
 TEST(UtilityClass, endswith) {
     std::string s1 = "isdahfaksjdfas asdf asdf sadffsaasdfkoö-.:fp9pfdas ";
@@ -104,9 +104,9 @@ TEST(UtilityClass, getLongLen) {
     EXPECT_EQ(4, getLongLen(l11));
 }
 
-TEST(UtilityClass, stringToBytes){
+TEST(UtilityClass, stringToBytes) {
     Bytes b1;
-    for(u_int64_t i = 0; i < 1000; i++){
+    for (u_int64_t i = 0; i < 1000; i++) {
         b1.setBytes(RNG::get_random_bytes(10));
         EXPECT_EQ(b1, stringToBytes(charVecToString(b1.getBytes())));
     }


### PR DESCRIPTION
added unittests for the overloaded methods.
The chainhashes are rewritten to get the same result for string and bytes
resolves #7 