### PR TITLE
Restructure dataheader

### DIFF
--- a/docs/dataheader.md
+++ b/docs/dataheader.md
@@ -17,8 +17,17 @@
 //WORK correct link of the docs
 |Bytes|Type|Doc|More Docs|
 |---|---|-------------|-----|
+|8|u_int64|how long is the whole file in Bytes|-|
+|8|u_int64|how long is the dataheader in Bytes|-|
 |1|unsigned char|which kind of data is in the file|[*file_data.md*](file_data.md)|
 |1|unsigned char|which hash function was used in this file|[*hash_modes.md*](hash_modes.md)|
+|1|unsigned char|how many datablocks are following|WORK|
+|||||
+|||DATABLOCKS||
+|1|unsigned char|which type of data is stored in that block|WORK|
+|1|unsigned char|how long is the datablock in Bytes|WORK|
+|0-255|Bytes|data of the datablock|WORK|
+|||||
 |1|unsigned char|which chainhash was used to get the passwordhash|- [*chainhash_modes.md*](chainhash_modes.md)|
 |8|u_int64|saves the number of iterations for turning the password into the passwordhash|[*bytes.md*](bytes.md)|
 |1|unsigned char|saves the length (in bytes) of the datablock for the first chainhash|- [*chainhash_modes.md*](chainhash_modes.md)|
@@ -29,16 +38,45 @@
 |0-255|Bytes|data block for the second chainhash|- [*chainhash_modes.md*](chainhash_modes.md)|
 |Hash size|Bytes|saves the bytes of a chainhash from the passwordhash to validate the password|-|
 |Hash size|Bytes|saves the encrypted salt|[*doc.md*](doc.md)|
-
+|1|unsigned char|how many decrypted datablocks are following|WORK|
+|||||
+|||DECRYPTED DATABLOCKS||
+|1|unsigned char|which type of data is stored in that block (encrypted)|WORK|
+|1|unsigned char|how long is the datablock in Bytes|WORK|
+|0-255|Bytes|data of the datablock (encrypted)|WORK|
+|||||
+|||||
 
 ### Total length of the data header lh:
-    22 + 2*HashSize <= lh <= 22 + 2*HashSize + 2*255 Bytes
+    lh = 40 + 2*HashSize + cs + d + ed
+    with: cs = cs1 + cs2 < 2*255 Bytes (chainhash-datablocks)
+          d = nd*2 + sdd    (datablocks)
+          ed = ned*2 + sedd (encrypted datablocks)
+
+    => lh = 40 + 2*HashSize + cs1 + cs2 + 2(nd+ned) + sdd + sedd
+
+    and:  cs1, cs2 = chainhash datablock sizes
+          nd = number of datablocks
+          sdd = sum of all data from datablocks
+          ned = number of encrypted datablocks
+          sedd = sum of all data from encryped datablocks
+
+
+|Hash size|Min lh|Max lh (without datablocks)|
+|---|---|---|
+|32|104|614|
+|48|136|646|
+|64|168|678|
+
+each datablock is adding between 2 and 257 Bytes on data.<br>
+There are 510 (2*255) datablocks maximum.
+That means that the maximum dataheader size is:
 
 |Hash size|Min lh|Max lh|
 |---|---|---|
-|32|86|596|
-|48|118|628|
-|64|150|660|
+|32|104|131684 (132KB)|
+|48|136|131716 (132KB)|
+|64|168|131748 (132KB)|
 
 ## DataHeaderSettings
 `DataHeaderSettings` are used in the `API` to create a new `DataHeader`. These structs contain all information that is needed to generate a new `DataHeader`.

--- a/docs/dataheader.md
+++ b/docs/dataheader.md
@@ -42,8 +42,8 @@
 |||||
 |||DECRYPTED DATABLOCKS||
 |1|unsigned char|which type of data is stored in that block (encrypted)|WORK|
-|1|unsigned char|how long is the datablock in Bytes|WORK|
-|0-255|Bytes|data of the datablock (encrypted)|WORK|
+|1|unsigned char|how long is the actual data in Bytes (encrypted)|WORK|
+|255|Bytes|data of the datablock (encrypted) + random salt bytes|WORK|
 |||||
 |||||
 
@@ -51,15 +51,14 @@
     lh = 40 + 2*HashSize + cs + d + ed
     with: cs = cs1 + cs2 < 2*255 Bytes (chainhash-datablocks)
           d = nd*2 + sdd    (datablocks)
-          ed = ned*2 + sedd (encrypted datablocks)
+          ed = ned*257 (encrypted datablocks)
 
-    => lh = 40 + 2*HashSize + cs1 + cs2 + 2(nd+ned) + sdd + sedd
+    => lh = 40 + 2*HashSize + cs1 + cs2 + 2*nd + 257*ned + sdd
 
     and:  cs1, cs2 = chainhash datablock sizes
           nd = number of datablocks
           sdd = sum of all data from datablocks
           ned = number of encrypted datablocks
-          sedd = sum of all data from encryped datablocks
 
 
 |Hash size|Min lh|Max lh (without datablocks)|

--- a/include/base.h
+++ b/include/base.h
@@ -30,6 +30,15 @@ enum FModes {
 // enum which describes a success type, an success type can be a success, fail or timeout
 enum SuccessType { SUCCESS, FAIL, TIMEOUT };
 
+// enum which holds the datablock types for the dataheader
+enum DatablockType {
+    DEFAULT = 0,
+    FILENAME,       // filename datablock type
+    FILEEXTENSION,  // fileextension datablock type
+    INDEX,          // index datablock type
+    TIMESTAMP,      // timestamp datablock type
+};
+
 // struct that is used as an data package between format and other classes
 // it contains the name of the chainhash block part and its length in bytes (or zero if it is a *B part)
 // chainhash_modes.md

--- a/include/bytes.h
+++ b/include/bytes.h
@@ -14,7 +14,7 @@ class Bytes {
     size_t max_len;          // max length of the byte array
     size_t len;              // length of the byte array
     bool deallocate = true;  // if the bytes array should be deallocated when the object is destroyed
-    Bytes(){
+    Bytes() {
         this->bytes = nullptr;
         this->max_len = 0;
         this->len = 0;
@@ -22,7 +22,7 @@ class Bytes {
 
    public:
     static Bytes fromLong(const u_int64_t l, const bool addzeros = false);  // sets the Bytes to the decimal representation of the given long
-    static Bytes withU64(const u_int64_t max_len) noexcept;                          // creates an empty byte array with a given maximum length
+    static Bytes withU64(const u_int64_t max_len) noexcept;                 // creates an empty byte array with a given maximum length
 
     Bytes(const int64_t max_len);                                    // creates an empty byte array with a given maximum length
     Bytes(unsigned char* bytes, const size_t len);                   // creates a Bytes object with the given bytes and length (consumes the array)

--- a/include/bytes.h
+++ b/include/bytes.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <fstream>
 #include <iostream>
 #include <memory>
-#include <fstream>
 
 class Bytes {
     /*

--- a/include/bytes.h
+++ b/include/bytes.h
@@ -14,9 +14,15 @@ class Bytes {
     size_t max_len;          // max length of the byte array
     size_t len;              // length of the byte array
     bool deallocate = true;  // if the bytes array should be deallocated when the object is destroyed
+    Bytes(){
+        this->bytes = nullptr;
+        this->max_len = 0;
+        this->len = 0;
+    }
 
    public:
     static Bytes fromLong(const u_int64_t l, const bool addzeros = false);  // sets the Bytes to the decimal representation of the given long
+    static Bytes withU64(const u_int64_t max_len) noexcept;                          // creates an empty byte array with a given maximum length
 
     Bytes(const int64_t max_len);                                    // creates an empty byte array with a given maximum length
     Bytes(unsigned char* bytes, const size_t len);                   // creates a Bytes object with the given bytes and length (consumes the array)

--- a/include/bytes.h
+++ b/include/bytes.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <memory>
+#include <fstream>
 
 class Bytes {
     /*
@@ -61,4 +62,6 @@ class Bytes {
             this->bytes = nullptr;
         }
     };  // destructor
+
+    friend std::ofstream& operator<<(std::ofstream& os, const Bytes& bytes);  // writes the bytes to the given ofstream
 };

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -251,6 +251,10 @@ struct DataHeaderSettingsIters {
     std::optional<u_int64_t> chainhash1_iters;  // iterations for the first chainhash
     std::optional<u_int64_t> chainhash2_iters;  // iterations for the second chainhash
    public:
+    std::vector<DataBlock> dec_data_blocks;     // the decrypted data blocks
+    std::vector<EncDataBlock> enc_data_blocks;  // the encrypted data blocks
+
+   public:
     bool isFileDataModeSet() const noexcept {
         // checks if the file data mode is set
         return this->file_mode.has_value();
@@ -420,6 +424,10 @@ struct DataHeaderSettingsTime {
     std::optional<CHModes> chainhash2_mode;    // chainhash mode for the second chainhash (passwordhash -> validate password)
     std::optional<u_int64_t> chainhash1_time;  // max miliseconds for the first chainhash
     std::optional<u_int64_t> chainhash2_time;  // max miliseconds for the second chainhash
+   public:
+    std::vector<DataBlock> dec_data_blocks;     // the decrypted data blocks
+    std::vector<EncDataBlock> enc_data_blocks;  // the encrypted data blocks
+   
    public:
     bool isFileDataModeSet() const noexcept {
         // checks if the file data mode is set
@@ -615,6 +623,7 @@ class DataHeader {
     void addEncDataBlock(const EncDataBlock encdatablock);    // adds an encrypted data block
 
     void setFileSize(const u_int64_t file_size);            // sets the file size
+    void setDataSize(const u_int32_t data_size);            // sets the file size by adding the header size to the data size
     std::optional<u_int64_t> getFileSize() const noexcept;  // gets the file size
     // calculates the header bytes with all information that is set, throws if not enough information is set (or not valid)
     // verifies the pwhash with the previous set pwhash validator

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -58,7 +58,7 @@ struct EncDataBlock {
         this->data_block.type = DatablockType((unsigned char)(datablock.type + pwhash.copySubBytes(0, 8).toLong()));
         u_int16_t written = 0;
         u_int16_t end;
-        Bytes enc_data{data_block.getData().getLen()};
+        Bytes enc_data = Bytes::withU64(data_block.getData().getLen());
         while(enc_data.getLen() < data_block.getData().getLen()) {
             // encrypt the data
             enc_salt = hash->hash(enc_salt - pwhash);
@@ -79,11 +79,11 @@ struct EncDataBlock {
         pwhash = hash->hash(pwhash);
         u_int16_t written = 0;
         u_int16_t end;
-        Bytes dec_data{this->data_block.getData().getLen()};
+        Bytes dec_data = Bytes::withU64(this->data_block.getData().getLen());
         while(dec_data.getLen() < this->data_block.getData().getLen()) {
             // decrypt the data
             enc_salt = hash->hash(enc_salt - pwhash);
-            end = std::min<int>(written + enc_salt.getLen(), data_block.getData().getLen());
+            end = std::min<int>(written + enc_salt.getLen(), this->data_block.getData().getLen());
             (this->data_block.getData().copySubBytes(written, end) - enc_salt.copySubBytes(0, end - written)).addcopyToBytes(dec_data);
         }
         return dec_data;

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -495,6 +495,7 @@ class DataHeader {
     DataHeaderParts dh;                           // saves every part of the header
     unsigned char hash_size;                      // the size of the hash provided by the hash function (in Bytes)
     Bytes header_bytes = Bytes(MAX_HEADER_SIZE);  // bytes that are in the header
+    std::optional<u_int64_t> file_size;           // the size of the file that is encrypted
 
    private:
     // checks if all data is set correctly
@@ -512,6 +513,8 @@ class DataHeader {
     void setChainHash1(const ChainHash chainhash);
     void setChainHash2(const ChainHash chainhash);
     void setValidPasswordHashBytes(const Bytes& validBytes);  // sets the passwordhashhash to validate the password hash
+    void setFileSize(const u_int64_t file_size);              // sets the file size
+    std::optional<u_int64_t> getFileSize() const noexcept;    // gets the file size
     // calculates the header bytes with all information that is set, throws if not enough information is set (or not valid)
     // verifies the pwhash with the previous set pwhash validator
     void calcHeaderBytes(const Bytes& passwordhash = Bytes(0));

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -47,7 +47,7 @@ struct EncDataBlock {
    public:
     static EncDataBlock createEncBlock(const unsigned char enc_type, const Bytes enc_data, const unsigned char enc_len) {
         // creates an EncDataBlock from the given data
-        if(enc_data.getLen() != 255){
+        if (enc_data.getLen() != 255) {
             PLOG_ERROR << "the given data has an invalid length: " << enc_data.getLen();
             throw std::invalid_argument("data has an invalid length");
         }

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -25,7 +25,7 @@ struct DataBlock {
 
     void setData(const Bytes& data) {
         // sets the data
-        if(data.getLen() > 0 && data.getLen() <= 255)   // the size has to be one byte
+        if (data.getLen() > 0 && data.getLen() <= 255)  // the size has to be one byte
             this->data = data;
         else {
             PLOG_ERROR << "the given data has an invalid length: " << data.getLen();
@@ -42,9 +42,9 @@ struct EncDataBlock {
    private:
     DataBlock data_block;  // the enc data
     EncDataBlock() = default;
-   public:
 
-    static EncDataBlock createEncBlock(const unsigned char enc_type, const Bytes enc_data){
+   public:
+    static EncDataBlock createEncBlock(const unsigned char enc_type, const Bytes enc_data) {
         // creates an EncDataBlock from the given data
         EncDataBlock enc_block;
         enc_block.data_block.type = DatablockType(enc_type);
@@ -59,7 +59,7 @@ struct EncDataBlock {
         u_int16_t written = 0;
         u_int16_t end;
         Bytes enc_data = Bytes::withU64(data_block.getData().getLen());
-        while(enc_data.getLen() < data_block.getData().getLen()) {
+        while (enc_data.getLen() < data_block.getData().getLen()) {
             // encrypt the data
             enc_salt = hash->hash(enc_salt - pwhash);
             end = std::min<int>(written + enc_salt.getLen(), data_block.getData().getLen());
@@ -69,18 +69,18 @@ struct EncDataBlock {
         this->data_block = datablock;
     }
 
-    Bytes getEnc() const noexcept{
+    Bytes getEnc() const noexcept {
         // gets the data
         return this->data_block.getData();
     }
 
-    Bytes getDec(const std::unique_ptr<Hash>&& hash, Bytes pwhash, Bytes enc_salt) const noexcept{
+    Bytes getDec(const std::unique_ptr<Hash>&& hash, Bytes pwhash, Bytes enc_salt) const noexcept {
         // decrypts the data
         pwhash = hash->hash(pwhash);
         u_int16_t written = 0;
         u_int16_t end;
         Bytes dec_data = Bytes::withU64(this->data_block.getData().getLen());
-        while(dec_data.getLen() < this->data_block.getData().getLen()) {
+        while (dec_data.getLen() < this->data_block.getData().getLen()) {
             // decrypt the data
             enc_salt = hash->hash(enc_salt - pwhash);
             end = std::min<int>(written + enc_salt.getLen(), this->data_block.getData().getLen());
@@ -110,10 +110,10 @@ struct DataHeaderParts {
     std::optional<Bytes> valid_passwordhash;  // saves the hash that should be the result of the second chainhash
     std::optional<Bytes> enc_salt;            // saves the encoded salt
    public:
-    std::vector<DataBlock> dec_data_blocks;  // the decrypted data blocks
+    std::vector<DataBlock> dec_data_blocks;     // the decrypted data blocks
     std::vector<EncDataBlock> enc_data_blocks;  // the encrypted data blocks
-    ChainHash chainhash1;  // chainhash data for the first chainhash (password -> passwordhash)
-    ChainHash chainhash2;  // chainhash data for the second chainhash (passwordhash -> validate password)
+    ChainHash chainhash1;                       // chainhash data for the first chainhash (password -> passwordhash)
+    ChainHash chainhash2;                       // chainhash data for the second chainhash (passwordhash -> validate password)
 
     bool isFileDataModeSet() const noexcept {
         // checks if the file data mode is set
@@ -217,8 +217,8 @@ struct DataHeaderParts {
     bool isComplete(const unsigned char hash_size) const noexcept {
         // checks if everything is set correctly
         try {
-            if (this->chainhash1.valid() && this->chainhash2.valid() && this->isValidPasswordHashSet() && this->isFileDataModeSet() && this->isHashModeSet() && this->getHashSize() == hash_size 
-                && this->isEncSaltSet())
+            if (this->chainhash1.valid() && this->chainhash2.valid() && this->isValidPasswordHashSet() && this->isFileDataModeSet() && this->isHashModeSet() && this->getHashSize() == hash_size &&
+                this->isEncSaltSet())
                 return true;  // everything is set correctly
         } catch (std::exception& e) {
             PLOG_WARNING << "isComplete thrown: " << e.what();
@@ -588,11 +588,11 @@ class DataHeader {
     more information about the header: docs/dataheader.md
     */
    private:
-    DataHeaderParts dh;                           // saves every part of the header
-    unsigned char hash_size;                      // the size of the hash provided by the hash function (in Bytes)
-    Bytes header_bytes = Bytes(0);                // bytes that are in the header
-    std::optional<u_int64_t> file_size;           // the size of the file that is encrypted
-    u_int32_t datablocks_len = 0;                 // the length of the datablocks
+    DataHeaderParts dh;                  // saves every part of the header
+    unsigned char hash_size;             // the size of the hash provided by the hash function (in Bytes)
+    Bytes header_bytes = Bytes(0);       // bytes that are in the header
+    std::optional<u_int64_t> file_size;  // the size of the file that is encrypted
+    u_int32_t datablocks_len = 0;        // the length of the datablocks
 
    private:
     // checks if all data is set correctly
@@ -611,11 +611,11 @@ class DataHeader {
     void setChainHash2(const ChainHash chainhash);
     void setValidPasswordHashBytes(const Bytes& validBytes);  // sets the passwordhashhash to validate the password hash
     void clearDataBlocks() noexcept;                          // clears the data blocks
-    void addDataBlock(const DataBlock datablock);            // adds a data block
-    void addEncDataBlock(const EncDataBlock encdatablock);   // adds an encrypted data block
+    void addDataBlock(const DataBlock datablock);             // adds a data block
+    void addEncDataBlock(const EncDataBlock encdatablock);    // adds an encrypted data block
 
-    void setFileSize(const u_int64_t file_size);              // sets the file size
-    std::optional<u_int64_t> getFileSize() const noexcept;    // gets the file size
+    void setFileSize(const u_int64_t file_size);            // sets the file size
+    std::optional<u_int64_t> getFileSize() const noexcept;  // gets the file size
     // calculates the header bytes with all information that is set, throws if not enough information is set (or not valid)
     // verifies the pwhash with the previous set pwhash validator
     void calcHeaderBytes(const Bytes& passwordhash = Bytes(0));

--- a/include/dataheader.h
+++ b/include/dataheader.h
@@ -427,7 +427,7 @@ struct DataHeaderSettingsTime {
    public:
     std::vector<DataBlock> dec_data_blocks;     // the decrypted data blocks
     std::vector<EncDataBlock> enc_data_blocks;  // the encrypted data blocks
-   
+
    public:
     bool isFileDataModeSet() const noexcept {
         // checks if the file data mode is set

--- a/include/error.h
+++ b/include/error.h
@@ -48,7 +48,9 @@ enum ErrorCode {
     ERR_DATAHEADERSETTINGS_INCOMPLETE,
     ERR_FILEDATASTRUCT_INCOMPLETE,
     ERR_FILEDATA_INVALID,
-    ERR_FILEDATASTRUCT_NULL
+    ERR_FILEDATASTRUCT_NULL,
+    ERR_FILESIZE_INVALID,
+    ERR_HEADERSIZE_FILESIZE_MISMATCH,
 };
 
 // used in a function that could fail, it returns a success type, a value and an error message
@@ -295,6 +297,12 @@ std::string getErrorMessage(ErrorStruct<T>& err, bool verbose_err_msg = true) no
 
         case ERR_FILEDATASTRUCT_NULL:
             return "FileDataStruct is null. It was moved previously" + err_msg;
+
+        case ERR_FILESIZE_INVALID:
+            return "Filesize is invalid: " + err.errorInfo + err_msg;
+
+        case ERR_HEADERSIZE_FILESIZE_MISMATCH:
+            return "Header size and filesize mismatch: " + err.errorInfo + err_msg;
 
         case ERR:
             if (err.errorInfo.empty()) return "An error occurred" + err_msg;

--- a/include/error.h
+++ b/include/error.h
@@ -51,6 +51,7 @@ enum ErrorCode {
     ERR_FILEDATASTRUCT_NULL,
     ERR_FILESIZE_INVALID,
     ERR_HEADERSIZE_FILESIZE_MISMATCH,
+    ERR_FILEHANDLER_CREATION,
 };
 
 // used in a function that could fail, it returns a success type, a value and an error message
@@ -303,6 +304,9 @@ std::string getErrorMessage(ErrorStruct<T>& err, bool verbose_err_msg = true) no
 
         case ERR_HEADERSIZE_FILESIZE_MISMATCH:
             return "Header size and filesize mismatch: " + err.errorInfo + err_msg;
+
+        case ERR_FILEHANDLER_CREATION:
+            return "FileHandler could not be created: " + err.errorInfo + err_msg;
 
         case ERR:
             if (err.errorInfo.empty()) return "An error occurred" + err_msg;

--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -14,6 +14,7 @@ class FileHandler {
     const std::filesystem::path filepath;  // stores the path to the encryption file
     size_t header_size = 0;                // stores the size of the data header
     size_t file_size = 0;                  // stores the size of the file
+    bool empty;                            // stores if the file is empty
    public:
     static const std::string extension;  // encryption files (.enc)
    public:
@@ -28,10 +29,13 @@ class FileHandler {
     std::ifstream getDataStream() const noexcept;                                                         // returns the data stream from the file (without the data header)
     size_t getHeaderSize() const noexcept;                                                                // returns the size of the data header
     size_t getFileSize() const noexcept;                                                                  // returns the length of the data in the file (without the data header)
+    
+    // NO update() needed
     Bytes getFirstBytes(const size_t num) const;                                                          // reads the first num Bytes from the encryption file
     Bytes getAllBytes() const;                                                                            // reads all Bytes from the given encryption file
-    ErrorStruct<bool> writeBytesIfEmpty(Bytes& bytes) noexcept;                                           // writes the given bytes to the file if it is empty
-    ErrorStruct<bool> writeBytes(Bytes& bytes) noexcept;                                                  // writes the given bytes to the file
+    
+    //ErrorStruct<bool> writeBytesIfEmpty(Bytes& bytes) noexcept;                                           // writes the given bytes to the file if it is empty
+    //ErrorStruct<bool> writeBytes(Bytes& bytes) noexcept;                                                  // writes the given bytes to the file
     ErrorStruct<std::ofstream> getWriteStream() noexcept;                                                 // returns a write stream to the file
     ErrorStruct<std::ofstream> getWriteStreamIfEmpty() noexcept;                                          // returns a write stream to the file if it is empty
     std::filesystem::path getPath() const noexcept;                                                       // returns the filepath

--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -29,14 +29,14 @@ class FileHandler {
     std::ifstream getDataStream() const noexcept;                                                         // returns the data stream from the file (without the data header)
     size_t getHeaderSize() const noexcept;                                                                // returns the size of the data header
     size_t getFileSize() const noexcept;                                                                  // returns the length of the data in the file (without the data header)
-    
+
     // NO update() needed
-    Bytes getFirstBytes(const size_t num) const;                                                          // reads the first num Bytes from the encryption file
-    Bytes getAllBytes() const;                                                                            // reads all Bytes from the given encryption file
-    
-    //ErrorStruct<bool> writeBytesIfEmpty(Bytes& bytes) noexcept;                                           // writes the given bytes to the file if it is empty
-    //ErrorStruct<bool> writeBytes(Bytes& bytes) noexcept;                                                  // writes the given bytes to the file
-    ErrorStruct<std::ofstream> getWriteStream() noexcept;                                                 // returns a write stream to the file
-    ErrorStruct<std::ofstream> getWriteStreamIfEmpty() noexcept;                                          // returns a write stream to the file if it is empty
-    std::filesystem::path getPath() const noexcept;                                                       // returns the filepath
+    Bytes getFirstBytes(const size_t num) const;  // reads the first num Bytes from the encryption file
+    Bytes getAllBytes() const;                    // reads all Bytes from the given encryption file
+
+    // ErrorStruct<bool> writeBytesIfEmpty(Bytes& bytes) noexcept;                                           // writes the given bytes to the file if it is empty
+    // ErrorStruct<bool> writeBytes(Bytes& bytes) noexcept;                                                  // writes the given bytes to the file
+    ErrorStruct<std::ofstream> getWriteStream() noexcept;         // returns a write stream to the file
+    ErrorStruct<std::ofstream> getWriteStreamIfEmpty() noexcept;  // returns a write stream to the file if it is empty
+    std::filesystem::path getPath() const noexcept;               // returns the filepath
 };

--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -28,7 +28,8 @@ class FileHandler {
     std::ifstream getFileStream() const noexcept;                                                         // returns the file stream
     std::ifstream getDataStream() const noexcept;                                                         // returns the data stream from the file (without the data header)
     size_t getHeaderSize() const noexcept;                                                                // returns the size of the data header
-    size_t getFileSize() const noexcept;                                                                  // returns the length of the data in the file (without the data header)
+    size_t getFileSize() const noexcept;                                                                  // returns the length of the file
+    size_t getDataSize() const noexcept;                                                                  // returns the length of the data in the file
 
     // NO update() needed
     Bytes getFirstBytes(const size_t num) const;  // reads the first num Bytes from the encryption file

--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -12,17 +12,22 @@ class FileHandler {
     */
    private:
     const std::filesystem::path filepath;  // stores the path to the encryption file
-    u_int64_t header_size = 0;             // stores the size of the data header
+    size_t header_size = 0;             // stores the size of the data header
+    size_t file_size = 0;               // stores the size of the file
    public:
     static const std::string extension;  // encryption files (.enc)
    public:
     static ErrorStruct<bool> isValidPath(const std::filesystem::path& file, bool should_exist) noexcept;  // checks if the path is valid
     static ErrorStruct<bool> createFile(const std::filesystem::path& file) noexcept;                      // creates a file
     FileHandler(const std::filesystem::path& file);                                                       // sets the filepath
+    void update();                                                                                        // updates the header_size and file_size variables
     ErrorStruct<bool> isDataHeader(FModes exp_file_mode) noexcept;                                        // checks if the file has a valid data header
     bool isEmtpy() const noexcept;                                                                        // checks if the file is empty
     ErrorStruct<std::unique_ptr<DataHeader>> getDataHeader() noexcept;                                    // reads the data header from the file
-    ErrorStruct<std::ifstream> getData() noexcept;                                                        // reads the data from the file (without the data header)
+    std::ifstream getFileStream() const noexcept;                                                         // returns the file stream
+    std::ifstream getDataStream() const noexcept;                                                         // returns the data stream from the file (without the data header)
+    size_t getHeaderSize() const noexcept;                                                                // returns the size of the data header
+    size_t getFileSize() const noexcept;                                                                  // returns the length of the data in the file (without the data header)
     Bytes getFirstBytes(const size_t num) const;                                                          // reads the first num Bytes from the encryption file
     Bytes getAllBytes() const;                                                                            // reads all Bytes from the given encryption file
     ErrorStruct<bool> writeBytesIfEmpty(Bytes& bytes) noexcept;                                           // writes the given bytes to the file if it is empty

--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -12,8 +12,8 @@ class FileHandler {
     */
    private:
     const std::filesystem::path filepath;  // stores the path to the encryption file
-    size_t header_size = 0;             // stores the size of the data header
-    size_t file_size = 0;               // stores the size of the file
+    size_t header_size = 0;                // stores the size of the data header
+    size_t file_size = 0;                  // stores the size of the file
    public:
     static const std::string extension;  // encryption files (.enc)
    public:

--- a/include/settings.h
+++ b/include/settings.h
@@ -43,3 +43,7 @@ const constexpr u_int64_t MAX_RUNTIME = 1000 * 60 * 60 * 24;  // 1 day
 // stores the number of iteration that can passed from the chainhash before the timeout is checked
 // a higher value does increase performance but leads to more inaccurate timeout calls
 const constexpr u_int64_t TIMEOUT_ITERATIONS = 1000;
+
+//##################### LENGTHS #######################
+// stores the minimum length of the dataheader
+const constexpr unsigned int MIN_DATAHEADER_LEN = 104;

--- a/include/settings.h
+++ b/include/settings.h
@@ -45,4 +45,4 @@ const constexpr u_int64_t MAX_RUNTIME = 1000 * 60 * 60 * 24;  // 1 day
 const constexpr u_int64_t TIMEOUT_ITERATIONS = 1000;
 
 //##################### HEADER ##########################
-const constexpr u_int16_t MAX_HEADER_SIZE = 22 + 2 * 64 + 2 * 255;
+const constexpr u_int16_t MAX_HEADER_SIZE = 38 + 2 * 64 + 2 * 255;

--- a/include/settings.h
+++ b/include/settings.h
@@ -43,6 +43,3 @@ const constexpr u_int64_t MAX_RUNTIME = 1000 * 60 * 60 * 24;  // 1 day
 // stores the number of iteration that can passed from the chainhash before the timeout is checked
 // a higher value does increase performance but leads to more inaccurate timeout calls
 const constexpr u_int64_t TIMEOUT_ITERATIONS = 1000;
-
-//##################### HEADER ##########################
-const constexpr u_int16_t MAX_HEADER_SIZE = 38 + 2 * 64 + 2 * 255;

--- a/include/utility.h
+++ b/include/utility.h
@@ -21,3 +21,7 @@ void addStringToBytes(const std::string& str, Bytes& bytes);
 unsigned int getLongLen(const u_int64_t& num) noexcept;
 // checks if a string is a valid number
 bool isValidNumber(const std::string& number, const bool accept_blank = false, const u_int64_t& lower_bound = 0, const u_int64_t& upper_bound = -1) noexcept;
+// reads the data from the stream and avoid buffering limits
+bool readData(std::istream& stream, Bytes& data, const unsigned int& size) noexcept;
+// data is at least size bytes long
+bool readData(std::istream& stream, unsigned char* data, const unsigned int& size) noexcept;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -17,9 +17,9 @@ ErrorStruct<std::unique_ptr<FileHandler>> API::_getFileHandler(const std::filesy
         PLOG_ERROR << "The file path is invalid (file path: " << file_path.c_str() << ", errorCode: " << +err1.errorCode << ", errorInfo: " << err1.errorInfo << ", what: " << err1.what << ")";
         return ErrorStruct<std::unique_ptr<FileHandler>>{err1.success, err1.errorCode, err1.errorInfo, err1.what};
     }
-    try{
+    try {
         return ErrorStruct<std::unique_ptr<FileHandler>>::createMove(std::move(std::make_unique<FileHandler>(file_path)));
-    }catch(const std::exception& e){
+    } catch (const std::exception& e) {
         // something went wrong while creating the file handler
         PLOG_ERROR << "Something went wrong while creating the file handler (what: " << e.what() << ")";
         return ErrorStruct<std::unique_ptr<FileHandler>>{SuccessType::FAIL, ErrorCode::ERR_FILEHANDLER_CREATION, "", e.what()};

--- a/src/blockchain.cpp
+++ b/src/blockchain.cpp
@@ -1,4 +1,5 @@
 #include "blockchain.h"
+#include "utility.h"
 
 #include <fstream>
 
@@ -36,11 +37,10 @@ void BlockChain::addData(std::ifstream&& filestream, const size_t stream_len) {
         // get the data that can be added on the last block to complete it
         // it is the minimum of the free space in the last block and the length of the remaining data
         Bytes data_part{std::min<int>(this->getFreeSpaceInLastBlock(), stream_len - written)};
-        if (filestream.readsome(reinterpret_cast<char*>(data_part.getBytes()), data_part.getMaxLen()) != data_part.getMaxLen()) {
+        if (!readData(filestream, data_part, data_part.getMaxLen())) {
             PLOG_FATAL << "could not read all bytes from file. streamsize: " << stream_len << ", written: " << written << ", data_part_len: " << data_part.getLen();
             throw std::runtime_error("could not read all bytes from file");
         }
-        data_part.setLen(data_part.getMaxLen());
         written += data_part.getLen();
         this->current_block->addData(data_part);
         // add a new block if data is left

--- a/src/blockchain.cpp
+++ b/src/blockchain.cpp
@@ -1,7 +1,8 @@
 #include "blockchain.h"
-#include "utility.h"
 
 #include <fstream>
+
+#include "utility.h"
 
 BlockChain::BlockChain(std::shared_ptr<Hash> hash, const Bytes& passwordhash, const Bytes& enc_salt) {
     // initialize the salt generator (iterator)

--- a/src/bytes.cpp
+++ b/src/bytes.cpp
@@ -20,6 +20,14 @@ Bytes Bytes::fromLong(const u_int64_t l, const bool addzeros) {
     return res;
 }
 
+Bytes Bytes::withU64(const u_int64_t max_len) noexcept{ 
+    Bytes b;
+    b.max_len = max_len;
+    b.len = 0;
+    b.bytes = new unsigned char[max_len];
+    return b;
+}
+
 Bytes::Bytes(const int64_t max_len) {
     // creates an empty byte array with a given maximum length
     if (max_len < 0) {

--- a/src/bytes.cpp
+++ b/src/bytes.cpp
@@ -365,3 +365,9 @@ u_int64_t Bytes::toLong() const {
     std::memcpy(&res, reversedBytes, this->len);
     return res;
 }
+
+std::ofstream& operator<<(std::ofstream& os, const Bytes& bytes) {
+    // writes the bytes to the given ofstream
+    os.write(reinterpret_cast<const char*>(bytes.bytes), bytes.len);
+    return os;
+}

--- a/src/bytes.cpp
+++ b/src/bytes.cpp
@@ -20,7 +20,7 @@ Bytes Bytes::fromLong(const u_int64_t l, const bool addzeros) {
     return res;
 }
 
-Bytes Bytes::withU64(const u_int64_t max_len) noexcept{ 
+Bytes Bytes::withU64(const u_int64_t max_len) noexcept {
     Bytes b;
     b.max_len = max_len;
     b.len = 0;

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -125,6 +125,18 @@ void DataHeader::setFileSize(const u_int64_t file_size) {
     this->file_size = file_size;
 }
 
+void DataHeader::setDataSize(const u_int32_t data_size) {
+    // sets the file size
+    PLOG_VERBOSE << "setting file size with data size: " << data_size;
+    if (!this->isComplete()) {
+        // header bytes cannot be calculated (data is missing)
+        PLOG_ERROR << "all dataheader parts have to be set to set the file size";
+        throw std::logic_error("all dataheader parts have to be set to set the file size");
+    }
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
+    this->file_size = data_size + this->getHeaderLength();
+}
+
 std::optional<u_int64_t> DataHeader::getFileSize() const noexcept { return this->file_size; }
 
 void DataHeader::setEncSalt(const Bytes& salt) {

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -103,7 +103,7 @@ void DataHeader::addEncDataBlock(const EncDataBlock encdatablock) {
         PLOG_ERROR << "there are already 255 encrypted datablocks";
         throw std::length_error("there are already 255 encrypted datablocks");
     }
-    // should be the same as 257 
+    // should be the same as 257
     this->datablocks_len += 2 + encdatablock.getEnc().getLen();  // 1 for type, 1 for len, len for data (255)
     this->dh.enc_data_blocks.push_back(encdatablock);
     this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
@@ -223,11 +223,11 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
         this->dh.getValidPasswordHash().addcopyToBytes(dataheader);                         // add password validator
         this->dh.getEncSalt().addcopyToBytes(dataheader);                                   // add encrypted salt
 
-        dataheader.addByte((unsigned char)this->dh.enc_data_blocks.size());     // add encrypted data block count byte
-        for (EncDataBlock& encdatablock : this->dh.enc_data_blocks) {           // add all encrypted data blocks
-            dataheader.addByte(encdatablock.getEncType());                      // add type byte
-            dataheader.addByte((unsigned char)encdatablock.getEncLen());        // add data length byte
-            encdatablock.getEnc().addcopyToBytes(dataheader);                   // add data
+        dataheader.addByte((unsigned char)this->dh.enc_data_blocks.size());  // add encrypted data block count byte
+        for (EncDataBlock& encdatablock : this->dh.enc_data_blocks) {        // add all encrypted data blocks
+            dataheader.addByte(encdatablock.getEncType());                   // add type byte
+            dataheader.addByte((unsigned char)encdatablock.getEncLen());     // add data length byte
+            encdatablock.getEnc().addcopyToBytes(dataheader);                // add data
         }
     } catch (std::length_error& ex) {
         // trying to add more bytes than previously calculated

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -586,7 +586,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
             err.what = ex.what();
             return err;
         }
-        try{
+        try {
             dh->calcHeaderBytes();
         } catch (const std::exception& ex) {
             // some other error occurred
@@ -803,7 +803,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
             bool copied = false;
             if (nl.len != 0) {
                 // got a data part with set length
-                tmp.setLen(0); // clear tmp
+                tmp.setLen(0);  // clear tmp
                 if (!readData(file, tmp, nl.len)) {
                     throw std::length_error("not enough data to read the chainhash data block 1");
                 }
@@ -812,7 +812,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
                 data_len += nl.len;
             } else {
                 // got a data parCHModest with * length (use the remaining bytes)
-                tmp.setLen(0); // clear tmp
+                tmp.setLen(0);  // clear tmp
                 if (!readData(file, tmp, ch1datablocklen - data_len)) {
                     throw std::length_error("not enough data to read the chainhash data block 1");
                 }
@@ -943,7 +943,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
             bool copied = false;
             if (nl.len != 0) {
                 // got a data part with set length
-                tmp.setLen(0); // clear tmp
+                tmp.setLen(0);  // clear tmp
                 if (!readData(file, tmp, nl.len)) {
                     throw std::length_error("not enough data to read the chainhash data block 2");
                 }
@@ -952,7 +952,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
                 data_len += nl.len;
             } else {
                 // got a data parCHModest with * length (use the remaining bytes)
-                tmp.setLen(0); // clear tmp
+                tmp.setLen(0);  // clear tmp
                 if (!readData(file, tmp, ch2datablocklen - data_len)) {
                     throw std::length_error("not enough data to read the chainhash data block 2");
                 }
@@ -1115,7 +1115,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         }
         dh->addEncDataBlock(EncDataBlock::createEncBlock(type, data));
     }
-    try{
+    try {
         dh->calcHeaderBytes();
     } catch (const std::exception& ex) {
         // some other error occurred

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -13,6 +13,10 @@ DataHeader::DataHeader(const HModes hash_mode) {
     this->dh.setHashMode(hash_mode);
     // initialize the hash size
     this->hash_size = HashModes::getHash(hash_mode)->getHashSize();
+    // generate the salt with random bytes
+    Bytes rand_salt(this->hash_size);
+    rand_salt.fillrandom();
+    this->dh.setEncSalt(rand_salt);                    // set the random generated encrypted salt
 }
 
 bool DataHeader::isComplete() const noexcept {
@@ -24,7 +28,8 @@ bool DataHeader::isComplete() const noexcept {
 unsigned int DataHeader::getHeaderLength() const noexcept {
     // gets the header len, if there is no header set try to calculate the len, else return 0
     if (this->dh.chainhash1.valid() && this->dh.chainhash2.valid())                                                                             // all data set to calculate the header length
-        return 38 + 2 * this->hash_size + this->dh.chainhash1.getChainHashData()->getLen() + this->dh.chainhash2.getChainHashData()->getLen();  // dataheader.md
+        return 40 + 2 * this->hash_size + this->datablocks_len +
+            this->dh.chainhash1.getChainHashData()->getLen() + this->dh.chainhash2.getChainHashData()->getLen();  // dataheader.md
     if (this->header_bytes.getLen() > 0) return this->header_bytes.getLen();                                                                    // header bytes are set, so we get this length
     return 0;                                                                                                                                   // not enough infos to get the header length
 }
@@ -69,6 +74,38 @@ void DataHeader::setValidPasswordHashBytes(const Bytes& validBytes) {
     // set the passwordhash validator hash
     PLOG_VERBOSE << "setting password validator hash: " << validBytes.toHex();
     this->dh.setValidPasswordHash(validBytes);
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
+}
+
+void DataHeader::clearDataBlocks() noexcept {
+    // clears the data blocks
+    this->datablocks_len = 0;
+    this->dh.dec_data_blocks.clear();
+    this->dh.enc_data_blocks.clear();
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
+}
+
+void DataHeader::addDataBlock(const DataBlock datablock) {
+    // adds a data block
+    if(this->dh.dec_data_blocks.size() >= 255) {
+        // there are already 255 datablocks
+        PLOG_ERROR << "there are already 255 datablocks";
+        throw std::length_error("there are already 255 datablocks");
+    }
+    this->datablocks_len += 2 + datablock.getData().getLen();   // 1 for type, 1 for len, len for data
+    this->dh.dec_data_blocks.push_back(datablock);
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
+}
+
+void DataHeader::addEncDataBlock(const EncDataBlock encdatablock) {
+    // adds an encrypted data block
+    if(this->dh.enc_data_blocks.size() >= 255) {
+        // there are already 255 encrypted datablocks
+        PLOG_ERROR << "there are already 255 encrypted datablocks";
+        throw std::length_error("there are already 255 encrypted datablocks");
+    }
+    this->datablocks_len += 2 + encdatablock.getEnc().getLen();  // 1 for type, 1 for len, len for data
+    this->dh.enc_data_blocks.push_back(encdatablock);
     this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
@@ -152,9 +189,17 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
     Bytes dataheader = Bytes(len);
     try {
         Bytes::fromLong(this->file_size.value(), true).addcopyToBytes(dataheader);          // add file size
-        Bytes::fromLong(len, true).addcopyToBytes(dataheader);                              // add hash size
+        Bytes::fromLong(len, true).addcopyToBytes(dataheader);                              // add header size
+
         dataheader.addByte(this->dh.getFileDataMode());                                     // add file mode byte
         dataheader.addByte(this->dh.getHashMode());                                         // add hash mode byte
+        
+        dataheader.addByte((unsigned char)this->dh.dec_data_blocks.size());                 // add data block count byte
+        for(DataBlock& datablock : this->dh.dec_data_blocks) {                              // add all data blocks
+            dataheader.addByte(datablock.type);                                             // add type byte
+            dataheader.addByte((unsigned char)datablock.getData().getLen());                // add data length byte
+            datablock.getData().addcopyToBytes(dataheader);                                 // add data
+        }
         dataheader.addByte(this->dh.chainhash1.getMode());                                  // add first chainhash mode byte
         Bytes::fromLong(this->dh.chainhash1.getIters(), true).addcopyToBytes(dataheader);   // add iterations for the first chainhash
         dataheader.addByte(this->dh.chainhash1.getChainHashData()->getLen());               // add datablock length byte
@@ -164,11 +209,14 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
         dataheader.addByte(this->dh.chainhash2.getChainHashData()->getLen());               // add datablock length byte
         this->dh.chainhash2.getChainHashData()->getDataBlock().addcopyToBytes(dataheader);  // add second datablock
         this->dh.getValidPasswordHash().addcopyToBytes(dataheader);                         // add password validator
-        // generate the salt with random bytes
-        Bytes rand_salt(this->hash_size);
-        rand_salt.fillrandom();
-        this->dh.setEncSalt(rand_salt);                    // set the random generated encrypted salt
         this->dh.getEncSalt().addcopyToBytes(dataheader);  // add encrypted salt
+
+        dataheader.addByte((unsigned char)this->dh.enc_data_blocks.size());                // add encrypted data block count byte
+        for(EncDataBlock& encdatablock : this->dh.enc_data_blocks) {                        // add all encrypted data blocks
+            dataheader.addByte(encdatablock.getEncType());                                  // add type byte
+            dataheader.addByte((unsigned char)encdatablock.getEnc().getLen());              // add data length byte
+            encdatablock.getEnc().addcopyToBytes(dataheader);                               // add data
+        }
     } catch (std::length_error& ex) {
         // trying to add more bytes than previously calculated
         PLOG_ERROR << "trying to add more bytes to the header than previously calculated (error msg: " << ex.what() << ")";
@@ -197,413 +245,412 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
     ErrorStruct<std::unique_ptr<DataHeader>> err{FAIL, ERR, "An error occurred while reading the header", "setHeaderBytes"};
     std::unique_ptr<DataHeader> dh = nullptr;
     // setting the header parts
-    //********************* FILEMODE *********************
+    u_int64_t file_size;
+    u_int64_t header_size;
     unsigned char fmode;
+    unsigned char hmode;
+    unsigned char data_block_count;
     u_int16_t index = 0;  // index of the current byte
-    try {
+
+    // ********************* FILESIZE *********************
+    try{
+        try {
+            // loading file size
+            file_size = fileBytes.copySubBytes(index, index + 8).toLong();
+        } catch (const std::length_error& ex) {
+            // copySubBytes failed because the length is reached
+            PLOG_ERROR << "not enogh data to read the file size (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = "File size";
+            err.what = ex.what();
+            return err;
+        }
+        index += 8;
+
+        try {
+            // loading file size
+            header_size = fileBytes.copySubBytes(index, index + 8).toLong();
+        } catch (const std::length_error& ex) {
+            // copySubBytes failed because the length is reached
+            PLOG_ERROR << "not enogh data to read the header size (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = "Header size";
+            err.what = ex.what();
+            return err;
+        }
+        index += 8;
+
+        if(header_size > fileBytes.getLen()) {
+            // header size is bigger than the file size
+            PLOG_ERROR << "header size is bigger than the given bytes (header_size: " << header_size << ", given bytes: " << fileBytes.getLen() << ")";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = " because the given header size is bigger than the given size";
+            err.what = "header size is bigger than the given bytes";
+            return err;
+        }
+        //********************* FILEMODE *********************
         // loading file mode
         fmode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enogh data to read the file mode (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "File mode";
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
+        index += 1;
 
-    // ********************* HASH FUNCTION *********************
-    unsigned char hmode;
-    try {
+        // ********************* HASH FUNCTION *********************
         // loading and setting hash mode
         hmode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-        dh = std::make_unique<DataHeader>(HModes(hmode));
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the hash mode (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Hash mode";
-        err.what = ex.what();
-        return err;
-    } catch (const std::invalid_argument& ex) {
-        // the hash mode is invalid
-        PLOG_ERROR << "invalid hash mode found in data (hash_mode: " << +hmode << ") (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_HASHMODE_INVALID;
-        err.errorInfo = hmode;
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
-
-    // setting the file data mode
-    try {
-        dh->setFileDataMode(FModes(fmode));
-    } catch (const std::invalid_argument& ex) {
-        // the file mode is invalid
-        PLOG_ERROR << "invalid file mode found in data (file_mode: " << +fmode << ") (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_FILEMODE_INVALID;
-        err.errorInfo = fmode;
-        err.what = ex.what();
-        return err;
-    }
-
-    // ********************* CHAINHASH1 *********************
-    std::shared_ptr<Format> format1 = nullptr;
-    std::shared_ptr<ChainHashData> chd1 = nullptr;
-    unsigned char ch1mode;
-    try {
-        ch1mode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-        format1 = std::make_shared<Format>(CHModes(ch1mode));
-        chd1 = std::make_shared<ChainHashData>(*format1);
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash mode 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash mode 1";
-        err.what = ex.what();
-        return err;
-    } catch (const std::invalid_argument& ex) {
-        // the chainhash mode is invalid
-        PLOG_ERROR << "invalid chainhash mode 1 found in data (chainhash_mode 1: " << +ch1mode << ") (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_CHAINHASHMODE_FORMAT_INVALID;
-        err.errorInfo = ch1mode;
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash mode 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash mode 1";
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
-    // chainhash 1 iters
-    u_int64_t ch1iters;
-    try {
-        ch1iters = fileBytes.copySubBytes(index, index + 8).toLong();
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash iters 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash iters 1";
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash iters 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash iters 1";
-        err.what = ex.what();
-        return err;
-    }
-    index += 8;
-    // chainhash 1 data block len
-    unsigned char ch1datablocklen;
-    try {
-        ch1datablocklen = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash data block len 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash data block len 1";
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
-    // chainhash 1 data block
-    int data_len = 0;
-    bool copied = false;
-    Bytes tmp{255};
-    for (NameLen nl : format1->getNameLenList()) {
+        index += 1;
         try {
-            bool copied = false;
-            if (nl.len != 0) {
-                // got a data part with set length
-                tmp = fileBytes.copySubBytes(index, index + nl.len);
-                copied = true;
-                chd1->addBytes(tmp);
-                index += nl.len;
-                data_len += nl.len;
-            } else {
-                // got a data parCHModest with * length (use the remaining bytes)
-                tmp = fileBytes.copySubBytes(index, index + (ch1datablocklen - data_len));
-                copied = true;
-                chd1->addBytes(tmp);
-                data_len = ch1datablocklen;
-                index += (ch1datablocklen - data_len);
-                break;
-            }
+            dh = std::make_unique<DataHeader>(HModes(hmode));
+        } catch (const std::invalid_argument& ex) {
+            // the hash mode is invalid
+            PLOG_ERROR << "invalid hash mode found in data (hash_mode: " << +hmode << ") (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_HASHMODE_INVALID;
+            err.errorInfo = hmode;
+            err.what = ex.what();
+            return err;
+        }
 
-        } catch (const std::length_error& ex) {
-            if (!copied) {
-                // copySubBytes failed because the length is reached
-                PLOG_ERROR << "not enough data to read the chainhash data block 1 (error msg: " << ex.what() << ")";
-                err.errorCode = ERR_NOT_ENOUGH_DATA;
-                err.errorInfo = "Chainhash data block 1";
-                err.what = ex.what();
-                return err;
-            } else {
+        // setting the file data mode
+        try {
+            dh->setFileDataMode(FModes(fmode));
+        } catch (const std::invalid_argument& ex) {
+            // the file mode is invalid
+            PLOG_ERROR << "invalid file mode found in data (file_mode: " << +fmode << ") (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_FILEMODE_INVALID;
+            err.errorInfo = fmode;
+            err.what = ex.what();
+            return err;
+        }
+
+        // ********************* DATABLOCKS *********************
+        // loading data blocks
+        data_block_count = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+        index += 1;
+        for(int i = 0; i < data_block_count; i++) {
+            // data block type
+            unsigned char type = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            index += 1;
+            // data block len
+            unsigned char len = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            index += 1;
+            // data block data
+            Bytes data = fileBytes.copySubBytes(index, index + len);
+            index += len;
+            dh->addDataBlock(DataBlock(DatablockType(type), data));
+        }
+
+        // ********************* CHAINHASH1 *********************
+        std::shared_ptr<Format> format1 = nullptr;
+        std::shared_ptr<ChainHashData> chd1 = nullptr;
+        unsigned char ch1mode;
+        try {
+            ch1mode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            format1 = std::make_shared<Format>(CHModes(ch1mode));
+            chd1 = std::make_shared<ChainHashData>(*format1);
+        } catch (const std::invalid_argument& ex) {
+            // the chainhash mode is invalid
+            PLOG_ERROR << "invalid chainhash mode 1 found in data (chainhash_mode 1: " << +ch1mode << ") (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_CHAINHASHMODE_FORMAT_INVALID;
+            err.errorInfo = ch1mode;
+            err.what = ex.what();
+            return err;
+        } catch (const std::exception& ex) {
+            // some other error occurred
+            PLOG_ERROR << "An error occurred while reading the chainhash mode 1 (error msg: " << ex.what() << ")";
+            err.errorCode = ERR;
+            err.errorInfo = "An error occurred while reading the chainhash mode 1";
+            err.what = ex.what();
+            return err;
+        }
+        index += 1;
+        // chainhash 1 iters
+        u_int64_t ch1iters = fileBytes.copySubBytes(index, index + 8).toLong();
+        index += 8;
+        // chainhash 1 data block len
+        unsigned char ch1datablocklen = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+        index += 1;
+        // chainhash 1 data block
+        int data_len = 0;
+        Bytes tmp{255};
+        for (NameLen nl : format1->getNameLenList()) {
+            try {
+                if (nl.len != 0) {
+                    // got a data part with set length
+                    tmp = fileBytes.copySubBytes(index, index + nl.len);
+                    chd1->addBytes(tmp);
+                    index += nl.len;
+                    data_len += nl.len;
+                } else {
+                    // got a data parCHModest with * length (use the remaining bytes)
+                    tmp = fileBytes.copySubBytes(index, index + (ch1datablocklen - data_len));
+                    chd1->addBytes(tmp);
+                    data_len = ch1datablocklen;
+                    index += (ch1datablocklen - data_len);
+                    break;
+                }
+
+            } catch (const std::length_error& ex) {
                 // adding to much bytes
                 PLOG_ERROR << "adding to much bytes to the chainhash data block 1 (error msg: " << ex.what() << ")";
                 err.errorCode = ERR_CHAINHASH_DATABLOCK_OUTOFRANGE;
                 err.errorInfo = tmp.toHex();
                 err.what = ex.what();
                 return err;
+            } catch (const std::invalid_argument& ex) {
+                // the bytes have the wrong len
+                PLOG_ERROR << "invalid format of the chainhash data block 1 (error msg: " << ex.what() << ")";
+                err.errorCode = ERR_CHAINHASH_DATAPART_INVALID;
+                err.errorInfo = tmp.toHex();
+                err.what = ex.what();
+                return err;
+            } catch (const std::logic_error& ex) {
+                // adding but its completed
+                PLOG_ERROR << "adding bytes to the chainhash data block 1 but its already completed (error msg: " << ex.what() << ")";
+                err.errorCode = ERR_CHAINHASH_DATABLOCK_ALREADY_COMPLETED;
+                err.errorInfo = tmp.toHex();
+                err.what = ex.what();
+                return err;
+            } catch (const std::exception& ex) {
+                // some other error occurred
+                PLOG_ERROR << "An error occurred while reading the chainhash data block 1 (error msg: " << ex.what() << ")";
+                err.errorCode = ERR;
+                err.errorInfo = "An error occurred while reading the chainhash data block 1";
+                err.what = ex.what();
+                return err;
             }
+        }
+        assert(chd1->getLen() == ch1datablocklen);
+        assert(data_len == ch1datablocklen);
+        // chainhash 1
+        try {
+            dh->setChainHash1(ChainHash{CHModes(ch1mode), ch1iters, chd1});
         } catch (const std::invalid_argument& ex) {
-            // the bytes have the wrong len
-            PLOG_ERROR << "invalid format of the chainhash data block 1 (error msg: " << ex.what() << ")";
-            err.errorCode = ERR_CHAINHASH_DATAPART_INVALID;
-            err.errorInfo = tmp.toHex();
-            err.what = ex.what();
-            return err;
-        } catch (const std::logic_error& ex) {
-            // adding but its completed
-            PLOG_ERROR << "adding bytes to the chainhash data block 1 but its already completed (error msg: " << ex.what() << ")";
-            err.errorCode = ERR_CHAINHASH_DATABLOCK_ALREADY_COMPLETED;
-            err.errorInfo = tmp.toHex();
+            // the chainhash is invalid
+            PLOG_ERROR << "invalid chainhash 1 (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_CHAINHASH1_INVALID;
             err.what = ex.what();
             return err;
         } catch (const std::exception& ex) {
             // some other error occurred
-            PLOG_ERROR << "An error occurred while reading the chainhash data block 1 (error msg: " << ex.what() << ")";
+            PLOG_ERROR << "An error occurred while setting the chainhash 1 (error msg: " << ex.what() << ")";
             err.errorCode = ERR;
-            err.errorInfo = "An error occurred while reading the chainhash data block 1";
+            err.errorInfo = "An error occurred while setting the chainhash data block 1";
             err.what = ex.what();
             return err;
         }
-    }
-    assert(chd1->getLen() == ch1datablocklen);
-    assert(data_len == ch1datablocklen);
-    // chainhash 1
-    try {
-        dh->setChainHash1(ChainHash{CHModes(ch1mode), ch1iters, chd1});
-    } catch (const std::invalid_argument& ex) {
-        // the chainhash is invalid
-        PLOG_ERROR << "invalid chainhash 1 (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_CHAINHASH1_INVALID;
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while setting the chainhash 1 (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while setting the chainhash data block 1";
-        err.what = ex.what();
-        return err;
-    }
 
-    // ********************* CHAINHASH2 *********************
-    std::shared_ptr<Format> format2 = nullptr;
-    std::shared_ptr<ChainHashData> chd2 = nullptr;
-    unsigned char ch2mode;
-    try {
-        ch2mode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-        format2 = std::make_shared<Format>(CHModes(ch2mode));
-        chd2 = std::make_shared<ChainHashData>(*format2);
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash mode 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash mode 2";
-        err.what = ex.what();
-        return err;
-    } catch (const std::invalid_argument& ex) {
-        // the chainhash mode is invalid
-        PLOG_ERROR << "invalid chainhash mode 2 found in data (chainhash_mode 2: " << +ch2mode << ") (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_CHAINHASHMODE_FORMAT_INVALID;
-        err.errorInfo = ch2mode;
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash mode 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash mode 2";
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
-    // chainhash 2 iters
-    u_int64_t ch2iters;
-    try {
-        ch2iters = fileBytes.copySubBytes(index, index + 8).toLong();
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash iters 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash iters 2";
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash iters 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash iters 2";
-        err.what = ex.what();
-        return err;
-    }
-    index += 8;
-    // chainhash 2 data block len
-    unsigned char ch2datablocklen;
-    try {
-        ch2datablocklen = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the chainhash data block len 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Chainhash data block len 2";
-        err.what = ex.what();
-        return err;
-    }
-    index += 1;
-    // chainhash 2 data block
-    data_len = 0;
-    copied = false;
-    for (NameLen nl : format2->getNameLenList()) {
+        // ********************* CHAINHASH2 *********************
+        std::shared_ptr<Format> format2 = nullptr;
+        std::shared_ptr<ChainHashData> chd2 = nullptr;
+        unsigned char ch2mode;
         try {
-            bool copied = false;
-            if (nl.len != 0) {
-                // got a data part with set length
-                tmp = fileBytes.copySubBytes(index, index + nl.len);
-                copied = true;
-                chd2->addBytes(tmp);
-                index += nl.len;
-                data_len += nl.len;
-            } else {
-                // got a data parCHModest with * length (use the remaining bytes)
-                tmp = fileBytes.copySubBytes(index, index + (ch2datablocklen - data_len));
-                copied = true;
-                chd2->addBytes(tmp);
-                data_len = ch2datablocklen;
-                index += (ch2datablocklen - data_len);
-                break;
-            }
+            ch2mode = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            format2 = std::make_shared<Format>(CHModes(ch2mode));
+            chd2 = std::make_shared<ChainHashData>(*format2);
+        } catch (const std::invalid_argument& ex) {
+            // the chainhash mode is invalid
+            PLOG_ERROR << "invalid chainhash mode 2 found in data (chainhash_mode 2: " << +ch2mode << ") (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_CHAINHASHMODE_FORMAT_INVALID;
+            err.errorInfo = ch2mode;
+            err.what = ex.what();
+            return err;
+        } catch (const std::exception& ex) {
+            // some other error occurred
+            PLOG_ERROR << "An error occurred while reading the chainhash mode 2 (error msg: " << ex.what() << ")";
+            err.errorCode = ERR;
+            err.errorInfo = "An error occurred while reading the chainhash mode 2";
+            err.what = ex.what();
+            return err;
+        }
+        index += 1;
+        // chainhash 2 iters
+        u_int64_t ch2iters = fileBytes.copySubBytes(index, index + 8).toLong();
+        index += 8;
+        // chainhash 2 data block len
+        unsigned char ch2datablocklen = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+        index += 1;
+        // chainhash 2 data block
+        data_len = 0;
+        for (NameLen nl : format2->getNameLenList()) {
+            try {
+                if (nl.len != 0) {
+                    // got a data part with set length
+                    tmp = fileBytes.copySubBytes(index, index + nl.len);
+                    chd2->addBytes(tmp);
+                    index += nl.len;
+                    data_len += nl.len;
+                } else {
+                    // got a data parCHModest with * length (use the remaining bytes)
+                    tmp = fileBytes.copySubBytes(index, index + (ch2datablocklen - data_len));
+                    chd2->addBytes(tmp);
+                    data_len = ch2datablocklen;
+                    index += (ch2datablocklen - data_len);
+                    break;
+                }
 
-        } catch (const std::length_error& ex) {
-            if (!copied) {
-                // popFirstBytes returned an empty optional
-                PLOG_ERROR << "not enough data to read the chainhash data block 2 (error msg: " << ex.what() << ")";
-                err.errorCode = ERR_NOT_ENOUGH_DATA;
-                err.errorInfo = "Chainhash data block 2";
-                err.what = ex.what();
-                return err;
-            } else {
+            } catch (const std::length_error& ex) {
                 // adding to much bytes
                 PLOG_ERROR << "adding to much bytes to the chainhash data block 2 (error msg: " << ex.what() << ")";
                 err.errorCode = ERR_CHAINHASH_DATABLOCK_OUTOFRANGE;
                 err.errorInfo = tmp.toHex();
                 err.what = ex.what();
                 return err;
+            } catch (const std::invalid_argument& ex) {
+                // the bytes have the wrong len
+                PLOG_ERROR << "invalid format of the chainhash data block 2 (error msg: " << ex.what() << ")";
+                err.errorCode = ERR_CHAINHASH_DATAPART_INVALID;
+                err.errorInfo = tmp.toHex();
+                err.what = ex.what();
+                return err;
+            } catch (const std::logic_error& ex) {
+                // adding but its completed
+                PLOG_ERROR << "adding bytes to the chainhash data block 2 but its already completed (error msg: " << ex.what() << ")";
+                err.errorCode = ERR_CHAINHASH_DATABLOCK_ALREADY_COMPLETED;
+                err.errorInfo = tmp.toHex();
+                err.what = ex.what();
+                return err;
+            } catch (const std::exception& ex) {
+                // some other error occurred
+                PLOG_ERROR << "An error occurred while reading the chainhash data block 2 (error msg: " << ex.what() << ")";
+                err.errorCode = ERR;
+                err.errorInfo = "An error occurred while reading the chainhash data block 2";
+                err.what = ex.what();
+                return err;
             }
+        }
+        assert(chd2->getLen() == ch2datablocklen);
+        assert(data_len == ch2datablocklen);
+        // chainhash 2
+        try {
+            dh->setChainHash2(ChainHash{CHModes(ch2mode), ch2iters, chd2});
         } catch (const std::invalid_argument& ex) {
-            // the bytes have the wrong len
-            PLOG_ERROR << "invalid format of the chainhash data block 2 (error msg: " << ex.what() << ")";
-            err.errorCode = ERR_CHAINHASH_DATAPART_INVALID;
-            err.errorInfo = tmp.toHex();
-            err.what = ex.what();
-            return err;
-        } catch (const std::logic_error& ex) {
-            // adding but its completed
-            PLOG_ERROR << "adding bytes to the chainhash data block 2 but its already completed (error msg: " << ex.what() << ")";
-            err.errorCode = ERR_CHAINHASH_DATABLOCK_ALREADY_COMPLETED;
-            err.errorInfo = tmp.toHex();
+            // the chainhash is invalid
+            PLOG_ERROR << "invalid chainhash 2 (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_CHAINHASH2_INVALID;
             err.what = ex.what();
             return err;
         } catch (const std::exception& ex) {
             // some other error occurred
-            PLOG_ERROR << "An error occurred while reading the chainhash data block 2 (error msg: " << ex.what() << ")";
+            PLOG_ERROR << "An error occurred while setting the chainhash 2 (error msg: " << ex.what() << ")";
             err.errorCode = ERR;
-            err.errorInfo = "An error occurred while reading the chainhash data block 2";
+            err.errorInfo = "An error occurred while setting the chainhash data block 2";
             err.what = ex.what();
             return err;
         }
-    }
-    assert(chd2->getLen() == ch2datablocklen);
-    assert(data_len == ch2datablocklen);
-    // chainhash 2
-    try {
-        dh->setChainHash2(ChainHash{CHModes(ch2mode), ch2iters, chd2});
-    } catch (const std::invalid_argument& ex) {
-        // the chainhash is invalid
-        PLOG_ERROR << "invalid chainhash 2 (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_CHAINHASH2_INVALID;
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while setting the chainhash 2 (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while setting the chainhash data block 2";
-        err.what = ex.what();
-        return err;
-    }
 
-    // password validator hash
-    try {
-        dh->setValidPasswordHashBytes(fileBytes.copySubBytes(index, index + dh->hash_size));
-        index += dh->hash_size;
-    } catch (const std::length_error& ex) {
-        // copySubBytes fauiled because the length is reached
-        PLOG_ERROR << "not enough data to read the password validator hash (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Password validator hash";
-        err.what = ex.what();
-        return err;
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while setting and reading the password validator hash (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while setting and reading the password validator hash";
-        err.what = ex.what();
-        return err;
-    }
+        // password validator hash
+        try {
+            dh->setValidPasswordHashBytes(fileBytes.copySubBytes(index, index + dh->hash_size));
+            index += dh->hash_size;
+        } catch (const std::exception& ex) {
+            // some other error occurred
+            PLOG_ERROR << "An error occurred while setting and reading the password validator hash (error msg: " << ex.what() << ")";
+            err.errorCode = ERR;
+            err.errorInfo = "An error occurred while setting and reading the password validator hash";
+            err.what = ex.what();
+            return err;
+        }
 
-    // encrypted salt
-    try {
-        dh->setEncSalt(fileBytes.copySubBytes(index, index + dh->hash_size));
-        index += dh->hash_size;
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the salt hash (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Password salt hash";
-        err.what = ex.what();
-        return err;
+        // encrypted salt
+        try {
+            dh->setEncSalt(fileBytes.copySubBytes(index, index + dh->hash_size));
+            index += dh->hash_size;
+        } catch (const std::exception& ex) {
+            // some other error occurred
+            PLOG_ERROR << "An error occurred while setting and reading the salt hash (error msg: " << ex.what() << ")";
+            err.errorCode = ERR;
+            err.errorInfo = "An error occurred while setting and reading the salt hash";
+            err.what = ex.what();
+            return err;
+        }
+
+        // ********************* ENCRYPTED DATABLOCKS *********************
+        // loading encrypted data blocks
+        unsigned char enc_data_block_count = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+        index += 1;
+        for(int i = 0; i < enc_data_block_count; i++) {
+            // data block type
+            unsigned char enc_type = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            index += 1;
+            // data block len
+            unsigned char len = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
+            index += 1;
+            // data block data
+            Bytes enc_data = fileBytes.copySubBytes(index, index + len);
+            index += len;
+            dh->addEncDataBlock(EncDataBlock::createEncBlock(enc_type, enc_data));
+        }
+        try{
+            dh->setFileSize(file_size);  // setting the file size
+        } catch(const std::invalid_argument& ex){
+            PLOG_ERROR << "invalid file size (error msg: " << ex.what() << ")";
+            err.errorCode = ERR_FILESIZE_INVALID;
+            err.errorInfo = file_size;
+            err.what = ex.what();
+            return err;
+        }
+        assert(index == header_size);
+        assert(dh->getHeaderLength() == header_size);
+        return ErrorStruct<std::unique_ptr<DataHeader>>::createMove(std::move(dh));
     } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while setting and reading the salt hash (error msg: " << ex.what() << ")";
-        err.success = FAIL;
+        PLOG_ERROR << "An error occurred while reading the header (error msg: " << ex.what() << ")";
         err.errorCode = ERR;
-        err.errorInfo = "An error occurred while setting and reading the salt hash";
+        err.errorInfo = "An error occurred while reading the header";
         err.what = ex.what();
         return err;
     }
-    assert(index == fileBytes.getLen());
-    return ErrorStruct<std::unique_ptr<DataHeader>>::createMove(std::move(dh));
 }
 
 ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstream& file) noexcept {
     // sets the header bytes by taking the first bytes of the file
     // init error struct
-    auto start = file.tellg();
     ErrorStruct<std::unique_ptr<DataHeader>> err{FAIL, ERR, "An error occurred while reading the header", "setHeaderBytes"};
     std::unique_ptr<DataHeader> dh = nullptr;
     // setting the header parts
-    //********************* FILEMODE *********************
+    u_int64_t file_size;
+    u_int64_t header_size;
+    Bytes tmp(8);
     unsigned char fmode;
+    unsigned char hmode;
+    // get stream length
+    std::streampos start = file.tellg();
+    file.seekg(0, std::ios::end);
+    std::streampos end = file.tellg();
+    file.seekg(start);
+    //********************* FILESIZE *********************
+    if (file.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
+        // readsome could not read the file size
+        PLOG_ERROR << "not enogh data to read the file size";
+        err.errorCode = ERR_NOT_ENOUGH_DATA;
+        err.errorInfo = "File size";
+        return err;
+    }
+    tmp.setLen(8);
+    file_size = tmp.toLong();
+    //********************* HEADERSIZE *********************
+    if (file.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
+        // readsome could not read the header size
+        PLOG_ERROR << "not enogh data to read the header size";
+        err.errorCode = ERR_NOT_ENOUGH_DATA;
+        err.errorInfo = "Header size";
+        return err;
+    }
+    header_size = tmp.toLong();
+    if(end - start != file_size){
+        // file size is not equal to the stream size
+        PLOG_ERROR << "file size is not equal to the given stream size (file_size: " << file_size << ", stream size: " << (end - start) << ")";
+        err.errorCode = ERR_FILESIZE_INVALID;
+        err.errorInfo = "file size is not equal to the given stream size (file_size: " + std::to_string(file_size) + ", stream size: " + std::to_string(end - start) + ")";
+        return err;
+    }
+    if(header_size > file_size){
+        // header size is bigger than the file size
+        PLOG_ERROR << "header size is bigger than the file size (header_size: " << header_size << ", file size: " << file_size << ")";
+        err.errorCode = ERR_HEADERSIZE_FILESIZE_MISMATCH;
+        err.errorInfo = "header size is bigger than the file size (header_size: " + std::to_string(header_size) + ", file size: " + std::to_string(file_size) + ")";
+        return err;
+    }
+    //********************* FILEMODE *********************
     // loading file mode
-    if (file.readsome(reinterpret_cast<char*>(&fmode), 1) != 1) {
+    if (file.readsome(reinterpret_cast<char*>(&file_size), 8) != 8) {
         // readsome could not read the file mode
         PLOG_ERROR << "not enogh data to read the file mode";
         err.errorCode = ERR_NOT_ENOUGH_DATA;
@@ -612,8 +659,6 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
     }
 
     // ********************* HASH FUNCTION *********************
-    unsigned char hmode;
-
     // loading and setting hash mode
     if (file.readsome(reinterpret_cast<char*>(&hmode), 1) != 1) {
         // readsome could not read the hash mode
@@ -622,6 +667,8 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = "Hash mode";
         return err;
     }
+
+
     try {
         dh = std::make_unique<DataHeader>(HModes(hmode));
     } catch (const std::invalid_argument& ex) {
@@ -644,6 +691,48 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = fmode;
         err.what = ex.what();
         return err;
+    }
+
+    // ********************* DATABLOCKS *********************
+    // loading data blocks
+    unsigned char data_block_count;
+    if (file.readsome(reinterpret_cast<char*>(&data_block_count), 1) != 1) {
+        // readsome could not read the data block count
+        PLOG_ERROR << "not enogh data to read the data block count";
+        err.errorCode = ERR_NOT_ENOUGH_DATA;
+        err.errorInfo = "Data block count";
+        return err;
+    }
+    for(int i = 0; i < data_block_count; i++) {
+        // data block type
+        unsigned char type;
+        if (file.readsome(reinterpret_cast<char*>(&type), 1) != 1) {
+            // readsome could not read the data block type
+            PLOG_ERROR << "not enogh data to read the data block type";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = "Data block type";
+            return err;
+        }
+        // data block len
+        unsigned char len;
+        if (file.readsome(reinterpret_cast<char*>(&len), 1) != 1) {
+            // readsome could not read the data block len
+            PLOG_ERROR << "not enogh data to read the data block len";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = "Data block len";
+            return err;
+        }
+        // data block data
+        Bytes data(len);
+        if (file.readsome(reinterpret_cast<char*>(data.getBytes()), len) != len) {
+            // readsome could not read the data block data
+            PLOG_ERROR << "not enogh data to read the data block data";
+            err.errorCode = ERR_NOT_ENOUGH_DATA;
+            err.errorInfo = "Data block data";
+            return err;
+        }
+        data.setLen(len);
+        dh->addDataBlock(DataBlock(DatablockType(type), data));
     }
 
     // ********************* CHAINHASH1 *********************
@@ -678,7 +767,6 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
     }
     // chainhash 1 iters
     u_int64_t ch1iters;
-    Bytes tmp{8};
     // loading and chainhash1 iters
     if (file.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
         // readsome could not read the chainhash1 iters
@@ -687,17 +775,8 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = "Chainhash1 iters";
         return err;
     }
-    try {
-        tmp.setLen(8);
-        ch1iters = tmp.toLong();
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash iters 1 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash iters 1";
-        err.what = ex.what();
-        return err;
-    }
+    tmp.setLen(8);
+    ch1iters = tmp.toLong();
     // chainhash 1 data block len
     unsigned char ch1datablocklen;
     // loading and chainhash1 blocklen
@@ -837,17 +916,8 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = "Chainhash2 iters";
         return err;
     }
-    try {
-        tmp.setLen(8);
-        ch2iters = tmp.toLong();
-    } catch (const std::exception& ex) {
-        // some other error occurred
-        PLOG_ERROR << "An error occurred while reading the chainhash iters 2 (error msg: " << ex.what() << ")";
-        err.errorCode = ERR;
-        err.errorInfo = "An error occurred while reading the chainhash iters 2";
-        err.what = ex.what();
-        return err;
-    }
+    tmp.setLen(8);
+    ch2iters = tmp.toLong();
     // chainhash 2 data block len
     unsigned char ch2datablocklen;
     // loading and chainhash1 blocklen
@@ -946,7 +1016,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         return err;
     }
 
-    // password validator hash
+    //********************* PASSWORD VALIDATOR HASH *********************
     try {
         Bytes tmp = Bytes(dh->hash_size);
         if (file.readsome(reinterpret_cast<char*>(tmp.getBytes()), dh->hash_size) != dh->hash_size) {
@@ -980,14 +1050,6 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         }
         tmp.setLen(dh->hash_size);
         dh->setEncSalt(tmp);
-    } catch (const std::length_error& ex) {
-        // copySubBytes failed because the length is reached
-        PLOG_ERROR << "not enough data to read the salt hash (error msg: " << ex.what() << ")";
-        err.success = FAIL;
-        err.errorCode = ERR_NOT_ENOUGH_DATA;
-        err.errorInfo = "Password salt hash";
-        err.what = ex.what();
-        return err;
     } catch (const std::exception& ex) {
         // some other error occurred
         PLOG_ERROR << "An error occurred while setting and reading the salt hash (error msg: " << ex.what() << ")";
@@ -997,7 +1059,17 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.what = ex.what();
         return err;
     }
+    try{
+        dh->setFileSize(file_size);  // setting the file size
+    } catch(const std::invalid_argument& ex){
+        PLOG_ERROR << "invalid file size (error msg: " << ex.what() << ")";
+        err.errorCode = ERR_FILESIZE_INVALID;
+        err.errorInfo = file_size;
+        err.what = ex.what();
+        return err;
+    }
     assert(start - file.tellg() == dh->getHeaderLength());
+    assert(dh->getHeaderLength() == header_size);
     return ErrorStruct<std::unique_ptr<DataHeader>>::createMove(std::move(dh));
 }
 
@@ -1011,8 +1083,13 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderParts(const DataHe
         dh->setChainHash1(dhp.chainhash1);                                                 // setting the chainhash 1
         dh->setChainHash2(dhp.chainhash2);                                                 // setting the chainhash 2
         dh->setValidPasswordHashBytes(dhp.getValidPasswordHash());                         // setting the password validator hash
-        if (dhp.isEncSaltSet())                                                            // enc salt is not necessary
-            dh->setEncSalt(dhp.getEncSalt());                                              // setting the encrypted salt
+        dh->setEncSalt(dhp.getEncSalt());                                                  // setting the encrypted salt
+        for(const DataBlock& db : dhp.dec_data_blocks) {                                   // setting the data blocks
+            dh->addDataBlock(db);
+        }
+        for(const EncDataBlock& edb : dhp.enc_data_blocks) {                               // setting the encrypted data blocks
+            dh->addEncDataBlock(edb);
+        }
 
         // success
         return ErrorStruct<std::unique_ptr<DataHeader>>::createMove(std::move(dh));

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -43,7 +43,7 @@ void DataHeader::setChainHash1(const ChainHash chainhash) {
     }
     // set the information to the object
     this->dh.chainhash1 = chainhash;
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 void DataHeader::setChainHash2(const ChainHash chainhash) {
@@ -55,21 +55,21 @@ void DataHeader::setChainHash2(const ChainHash chainhash) {
     }
     // set the information to the object
     this->dh.chainhash2 = chainhash;
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 void DataHeader::setFileDataMode(const FModes file_mode) {
     // sets the file data mode
     PLOG_VERBOSE << "setting file mode: " << +file_mode;
     this->dh.setFileDataMode(file_mode);
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 void DataHeader::setValidPasswordHashBytes(const Bytes& validBytes) {
     // set the passwordhash validator hash
     PLOG_VERBOSE << "setting password validator hash: " << validBytes.toHex();
     this->dh.setValidPasswordHash(validBytes);
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 void DataHeader::setFileSize(const u_int64_t file_size) {
@@ -80,22 +80,22 @@ void DataHeader::setFileSize(const u_int64_t file_size) {
         PLOG_ERROR << "all dataheader parts have to be set to set the file size";
         throw std::logic_error("all dataheader parts have to be set to set the file size");
     }
-    if(file_size < this->getHeaderLength()){
+    if (file_size < this->getHeaderLength()) {
         // file size is to small
         PLOG_ERROR << "file size is to small (file_size: " << file_size << ", header_length: " << this->getHeaderLength() << ")";
         throw std::invalid_argument("file size is to small");
     }
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
     this->file_size = file_size;
 }
 
-std::optional<u_int64_t> DataHeader::getFileSize() const noexcept { return this->file_size;}
+std::optional<u_int64_t> DataHeader::getFileSize() const noexcept { return this->file_size; }
 
 void DataHeader::setEncSalt(const Bytes& salt) {
     // sets the salt
     PLOG_VERBOSE << "setting salt: " << salt.toHex();
     this->dh.setEncSalt(salt);
-    this->header_bytes.setLen(0); // clear header bytes because they have to be recalculated
+    this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 Bytes DataHeader::getHeaderBytes() const {
@@ -122,13 +122,13 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
         PLOG_ERROR << "not all required data is set to calculate the header bytes";
         throw std::logic_error("not all required data is set to calculate the header bytes");
     }
-    if(!this->file_size.has_value()){
+    if (!this->file_size.has_value()) {
         // file size is not set
         PLOG_ERROR << "file size is not set";
         throw std::logic_error("file size is not set");
     }
     // file size is set
-    if(this->file_size.value() < this->getHeaderLength()){
+    if (this->file_size.value() < this->getHeaderLength()) {
         // file size is to small
         PLOG_ERROR << "file size is to small (file_size: " << this->file_size.value() << ", header_length: " << this->getHeaderLength() << ")";
         throw std::invalid_argument("file size is to small");
@@ -151,11 +151,11 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
 
     Bytes dataheader = Bytes(len);
     try {
-        Bytes::fromLong(this->file_size.value(), true).addcopyToBytes(dataheader);  // add file size
-        Bytes::fromLong(len, true).addcopyToBytes(dataheader);         // add hash size
-        dataheader.addByte(this->dh.getFileDataMode());     // add file mode byte
-        dataheader.addByte(this->dh.getHashMode());         // add hash mode byte
-        dataheader.addByte(this->dh.chainhash1.getMode());  // add first chainhash mode byte
+        Bytes::fromLong(this->file_size.value(), true).addcopyToBytes(dataheader);          // add file size
+        Bytes::fromLong(len, true).addcopyToBytes(dataheader);                              // add hash size
+        dataheader.addByte(this->dh.getFileDataMode());                                     // add file mode byte
+        dataheader.addByte(this->dh.getHashMode());                                         // add hash mode byte
+        dataheader.addByte(this->dh.chainhash1.getMode());                                  // add first chainhash mode byte
         Bytes::fromLong(this->dh.chainhash1.getIters(), true).addcopyToBytes(dataheader);   // add iterations for the first chainhash
         dataheader.addByte(this->dh.chainhash1.getChainHashData()->getLen());               // add datablock length byte
         this->dh.chainhash1.getChainHashData()->getDataBlock().addcopyToBytes(dataheader);  // add first datablock

--- a/src/dataheader.cpp
+++ b/src/dataheader.cpp
@@ -16,7 +16,7 @@ DataHeader::DataHeader(const HModes hash_mode) {
     // generate the salt with random bytes
     Bytes rand_salt(this->hash_size);
     rand_salt.fillrandom();
-    this->dh.setEncSalt(rand_salt);                    // set the random generated encrypted salt
+    this->dh.setEncSalt(rand_salt);  // set the random generated encrypted salt
 }
 
 bool DataHeader::isComplete() const noexcept {
@@ -27,11 +27,10 @@ bool DataHeader::isComplete() const noexcept {
 
 unsigned int DataHeader::getHeaderLength() const noexcept {
     // gets the header len, if there is no header set try to calculate the len, else return 0
-    if (this->dh.chainhash1.valid() && this->dh.chainhash2.valid())                                                                             // all data set to calculate the header length
-        return 40 + 2 * this->hash_size + this->datablocks_len +
-            this->dh.chainhash1.getChainHashData()->getLen() + this->dh.chainhash2.getChainHashData()->getLen();  // dataheader.md
-    if (this->header_bytes.getLen() > 0) return this->header_bytes.getLen();                                                                    // header bytes are set, so we get this length
-    return 0;                                                                                                                                   // not enough infos to get the header length
+    if (this->dh.chainhash1.valid() && this->dh.chainhash2.valid())  // all data set to calculate the header length
+        return 40 + 2 * this->hash_size + this->datablocks_len + this->dh.chainhash1.getChainHashData()->getLen() + this->dh.chainhash2.getChainHashData()->getLen();  // dataheader.md
+    if (this->header_bytes.getLen() > 0) return this->header_bytes.getLen();  // header bytes are set, so we get this length
+    return 0;                                                                 // not enough infos to get the header length
 }
 
 int DataHeader::getHashSize() const noexcept {
@@ -87,19 +86,19 @@ void DataHeader::clearDataBlocks() noexcept {
 
 void DataHeader::addDataBlock(const DataBlock datablock) {
     // adds a data block
-    if(this->dh.dec_data_blocks.size() >= 255) {
+    if (this->dh.dec_data_blocks.size() >= 255) {
         // there are already 255 datablocks
         PLOG_ERROR << "there are already 255 datablocks";
         throw std::length_error("there are already 255 datablocks");
     }
-    this->datablocks_len += 2 + datablock.getData().getLen();   // 1 for type, 1 for len, len for data
+    this->datablocks_len += 2 + datablock.getData().getLen();  // 1 for type, 1 for len, len for data
     this->dh.dec_data_blocks.push_back(datablock);
     this->header_bytes.setLen(0);  // clear header bytes because they have to be recalculated
 }
 
 void DataHeader::addEncDataBlock(const EncDataBlock encdatablock) {
     // adds an encrypted data block
-    if(this->dh.enc_data_blocks.size() >= 255) {
+    if (this->dh.enc_data_blocks.size() >= 255) {
         // there are already 255 encrypted datablocks
         PLOG_ERROR << "there are already 255 encrypted datablocks";
         throw std::length_error("there are already 255 encrypted datablocks");
@@ -188,17 +187,17 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
 
     Bytes dataheader = Bytes(len);
     try {
-        Bytes::fromLong(this->file_size.value(), true).addcopyToBytes(dataheader);          // add file size
-        Bytes::fromLong(len, true).addcopyToBytes(dataheader);                              // add header size
+        Bytes::fromLong(this->file_size.value(), true).addcopyToBytes(dataheader);  // add file size
+        Bytes::fromLong(len, true).addcopyToBytes(dataheader);                      // add header size
 
-        dataheader.addByte(this->dh.getFileDataMode());                                     // add file mode byte
-        dataheader.addByte(this->dh.getHashMode());                                         // add hash mode byte
-        
-        dataheader.addByte((unsigned char)this->dh.dec_data_blocks.size());                 // add data block count byte
-        for(DataBlock& datablock : this->dh.dec_data_blocks) {                              // add all data blocks
-            dataheader.addByte(datablock.type);                                             // add type byte
-            dataheader.addByte((unsigned char)datablock.getData().getLen());                // add data length byte
-            datablock.getData().addcopyToBytes(dataheader);                                 // add data
+        dataheader.addByte(this->dh.getFileDataMode());  // add file mode byte
+        dataheader.addByte(this->dh.getHashMode());      // add hash mode byte
+
+        dataheader.addByte((unsigned char)this->dh.dec_data_blocks.size());   // add data block count byte
+        for (DataBlock& datablock : this->dh.dec_data_blocks) {               // add all data blocks
+            dataheader.addByte(datablock.type);                               // add type byte
+            dataheader.addByte((unsigned char)datablock.getData().getLen());  // add data length byte
+            datablock.getData().addcopyToBytes(dataheader);                   // add data
         }
         dataheader.addByte(this->dh.chainhash1.getMode());                                  // add first chainhash mode byte
         Bytes::fromLong(this->dh.chainhash1.getIters(), true).addcopyToBytes(dataheader);   // add iterations for the first chainhash
@@ -209,13 +208,13 @@ void DataHeader::calcHeaderBytes(const Bytes& passwordhash) {
         dataheader.addByte(this->dh.chainhash2.getChainHashData()->getLen());               // add datablock length byte
         this->dh.chainhash2.getChainHashData()->getDataBlock().addcopyToBytes(dataheader);  // add second datablock
         this->dh.getValidPasswordHash().addcopyToBytes(dataheader);                         // add password validator
-        this->dh.getEncSalt().addcopyToBytes(dataheader);  // add encrypted salt
+        this->dh.getEncSalt().addcopyToBytes(dataheader);                                   // add encrypted salt
 
-        dataheader.addByte((unsigned char)this->dh.enc_data_blocks.size());                // add encrypted data block count byte
-        for(EncDataBlock& encdatablock : this->dh.enc_data_blocks) {                        // add all encrypted data blocks
-            dataheader.addByte(encdatablock.getEncType());                                  // add type byte
-            dataheader.addByte((unsigned char)encdatablock.getEnc().getLen());              // add data length byte
-            encdatablock.getEnc().addcopyToBytes(dataheader);                               // add data
+        dataheader.addByte((unsigned char)this->dh.enc_data_blocks.size());     // add encrypted data block count byte
+        for (EncDataBlock& encdatablock : this->dh.enc_data_blocks) {           // add all encrypted data blocks
+            dataheader.addByte(encdatablock.getEncType());                      // add type byte
+            dataheader.addByte((unsigned char)encdatablock.getEnc().getLen());  // add data length byte
+            encdatablock.getEnc().addcopyToBytes(dataheader);                   // add data
         }
     } catch (std::length_error& ex) {
         // trying to add more bytes than previously calculated
@@ -253,7 +252,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
     u_int16_t index = 0;  // index of the current byte
 
     // ********************* FILESIZE *********************
-    try{
+    try {
         try {
             // loading file size
             file_size = fileBytes.copySubBytes(index, index + 8).toLong();
@@ -280,7 +279,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
         }
         index += 8;
 
-        if(header_size > fileBytes.getLen()) {
+        if (header_size > fileBytes.getLen()) {
             // header size is bigger than the file size
             PLOG_ERROR << "header size is bigger than the given bytes (header_size: " << header_size << ", given bytes: " << fileBytes.getLen() << ")";
             err.errorCode = ERR_NOT_ENOUGH_DATA;
@@ -324,7 +323,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
         // loading data blocks
         data_block_count = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
         index += 1;
-        for(int i = 0; i < data_block_count; i++) {
+        for (int i = 0; i < data_block_count; i++) {
             // data block type
             unsigned char type = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
             index += 1;
@@ -566,7 +565,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
         // loading encrypted data blocks
         unsigned char enc_data_block_count = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
         index += 1;
-        for(int i = 0; i < enc_data_block_count; i++) {
+        for (int i = 0; i < enc_data_block_count; i++) {
             // data block type
             unsigned char enc_type = fileBytes.copySubBytes(index, index + 1).getBytes()[0];
             index += 1;
@@ -578,9 +577,9 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(Bytes& fileB
             index += len;
             dh->addEncDataBlock(EncDataBlock::createEncBlock(enc_type, enc_data));
         }
-        try{
+        try {
             dh->setFileSize(file_size);  // setting the file size
-        } catch(const std::invalid_argument& ex){
+        } catch (const std::invalid_argument& ex) {
             PLOG_ERROR << "invalid file size (error msg: " << ex.what() << ")";
             err.errorCode = ERR_FILESIZE_INVALID;
             err.errorInfo = file_size;
@@ -634,14 +633,14 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         return err;
     }
     header_size = tmp.toLong();
-    if(end - start != file_size){
+    if (end - start != file_size) {
         // file size is not equal to the stream size
         PLOG_ERROR << "file size is not equal to the given stream size (file_size: " << file_size << ", stream size: " << (end - start) << ")";
         err.errorCode = ERR_FILESIZE_INVALID;
         err.errorInfo = "file size is not equal to the given stream size (file_size: " + std::to_string(file_size) + ", stream size: " + std::to_string(end - start) + ")";
         return err;
     }
-    if(header_size > file_size){
+    if (header_size > file_size) {
         // header size is bigger than the file size
         PLOG_ERROR << "header size is bigger than the file size (header_size: " << header_size << ", file size: " << file_size << ")";
         err.errorCode = ERR_HEADERSIZE_FILESIZE_MISMATCH;
@@ -667,7 +666,6 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = "Hash mode";
         return err;
     }
-
 
     try {
         dh = std::make_unique<DataHeader>(HModes(hmode));
@@ -703,7 +701,7 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.errorInfo = "Data block count";
         return err;
     }
-    for(int i = 0; i < data_block_count; i++) {
+    for (int i = 0; i < data_block_count; i++) {
         // data block type
         unsigned char type;
         if (file.readsome(reinterpret_cast<char*>(&type), 1) != 1) {
@@ -1059,9 +1057,9 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderBytes(std::ifstrea
         err.what = ex.what();
         return err;
     }
-    try{
+    try {
         dh->setFileSize(file_size);  // setting the file size
-    } catch(const std::invalid_argument& ex){
+    } catch (const std::invalid_argument& ex) {
         PLOG_ERROR << "invalid file size (error msg: " << ex.what() << ")";
         err.errorCode = ERR_FILESIZE_INVALID;
         err.errorInfo = file_size;
@@ -1084,10 +1082,10 @@ ErrorStruct<std::unique_ptr<DataHeader>> DataHeader::setHeaderParts(const DataHe
         dh->setChainHash2(dhp.chainhash2);                                                 // setting the chainhash 2
         dh->setValidPasswordHashBytes(dhp.getValidPasswordHash());                         // setting the password validator hash
         dh->setEncSalt(dhp.getEncSalt());                                                  // setting the encrypted salt
-        for(const DataBlock& db : dhp.dec_data_blocks) {                                   // setting the data blocks
+        for (const DataBlock& db : dhp.dec_data_blocks) {                                  // setting the data blocks
             dh->addDataBlock(db);
         }
-        for(const EncDataBlock& edb : dhp.enc_data_blocks) {                               // setting the encrypted data blocks
+        for (const EncDataBlock& edb : dhp.enc_data_blocks) {  // setting the encrypted data blocks
             dh->addEncDataBlock(edb);
         }
 

--- a/src/filehandler.cpp
+++ b/src/filehandler.cpp
@@ -169,6 +169,8 @@ size_t FileHandler::getHeaderSize() const noexcept { return this->header_size; }
 
 size_t FileHandler::getFileSize() const noexcept { return this->file_size; }
 
+size_t FileHandler::getDataSize() const noexcept { return this->file_size - this->header_size; }
+
 // ErrorStruct<bool> FileHandler::writeBytes(Bytes& bytes) noexcept {
 //     // writes bytes to the file
 //     // overrides old content

--- a/src/filehandler.cpp
+++ b/src/filehandler.cpp
@@ -96,27 +96,27 @@ void FileHandler::update() {
     this->file_size = end - begin;
     filestream.seekg(begin);
     Bytes tmp(8);
-    if(filestream.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
-        if(this->file_size == 0)
+    if (filestream.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
+        if (this->file_size == 0)
             this->header_size = 0;
-        else{
+        else {
             PLOG_ERROR << "The file is too small to contain a data header but is not empty";
             throw std::length_error("The file is too small to contain a data header but is not empty");
         }
     }
     tmp.setLen(8);
-    if(tmp.toLong() != this->file_size){
+    if (tmp.toLong() != this->file_size) {
         PLOG_ERROR << "The file size does not match with the file size in the data header";
         throw std::logic_error("The file size does not match with the file size in the data header");
     }
-    if(filestream.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
+    if (filestream.readsome(reinterpret_cast<char*>(tmp.getBytes()), 8) != 8) {
         PLOG_ERROR << "The file is too small to contain a data header but is not empty";
         throw std::length_error("The file is too small to contain a data header but is not empty");
     }
     tmp.setLen(8);
     this->header_size = tmp.toLong();
     filestream.close();
-    if(this->header_size > this->file_size){
+    if (this->header_size > this->file_size) {
         PLOG_ERROR << "The file size is smaller than the given header size";
         throw std::logic_error("The file size is smaller than the given header size");
     }
@@ -274,8 +274,8 @@ Bytes FileHandler::getFirstBytes(const size_t num) const {
         // the set encryption file does not exist on the system
         throw std::runtime_error("file cannot be opened");
     }
-    Bytes b(num);  // creates a buffer to hold the read bytes
-    if (file.readsome(reinterpret_cast<char*>(b.getBytes()), num) != num){  // reads into the buffer
+    Bytes b(num);                                                            // creates a buffer to hold the read bytes
+    if (file.readsome(reinterpret_cast<char*>(b.getBytes()), num) != num) {  // reads into the buffer
         // not enough characters to read (file is not long enough)
         throw std::length_error("File contains to few characters");
     }

--- a/src/filehandler.cpp
+++ b/src/filehandler.cpp
@@ -3,11 +3,11 @@ implements the FileHandler class
 */
 
 #include "filehandler.h"
-#include "utility.h"
 
 #include <fstream>
 
 #include "logger.h"
+#include "utility.h"
 
 const std::string FileHandler::extension = ".enc";
 
@@ -105,12 +105,12 @@ void FileHandler::update() {
             PLOG_ERROR << "The file is too small to contain a data header but is not empty";
             throw std::length_error("The file is too small to contain a data header but is not empty");
         }
-    } else{
+    } else {
         if (tmp.toLong() != this->file_size) {
             PLOG_ERROR << "The file size does not match with the file size in the data header";
             throw std::logic_error("The file size does not match with the file size in the data header");
         }
-        tmp.setLen(0); // reset the length
+        tmp.setLen(0);  // reset the length
         if (!readData(filestream, tmp, 8)) {
             PLOG_ERROR << "The file is too small to contain a data header but is not empty";
             throw std::length_error("The file is too small to contain a data header but is not empty");
@@ -122,7 +122,7 @@ void FileHandler::update() {
         PLOG_ERROR << "The file size is smaller than the given header size";
         throw std::logic_error("The file size is smaller than the given header size");
     }
-    if(this->header_size < MIN_DATAHEADER_LEN && !(this->header_size == 0 && this->file_size == 0)){
+    if (this->header_size < MIN_DATAHEADER_LEN && !(this->header_size == 0 && this->file_size == 0)) {
         PLOG_ERROR << "The file is too small to contain a data header but is not empty";
         throw std::length_error("The file is too small to contain a data header but is not empty");
     }
@@ -143,9 +143,7 @@ ErrorStruct<bool> FileHandler::isDataHeader(FModes exp_file_mode) noexcept {
     return ErrorStruct<bool>{FAIL, ERR_FILEMODE_INVALID, std::to_string(+err.returnRef()->getDataHeaderParts().getFileDataMode())};
 }
 
-bool FileHandler::isEmtpy() const noexcept {
-    return this->empty;
-}
+bool FileHandler::isEmtpy() const noexcept { return this->empty; }
 
 ErrorStruct<std::unique_ptr<DataHeader>> FileHandler::getDataHeader() noexcept {
     // reads the data header from the file
@@ -258,7 +256,7 @@ Bytes FileHandler::getAllBytes() const {
 
     // gets the Bytes
     Bytes ret(file_size);
-    if(!readData(file, ret, file_size)){
+    if (!readData(file, ret, file_size)) {
         // not enough characters to read (file is not long enough)
         throw std::length_error("File contains to few characters");
     }
@@ -273,7 +271,7 @@ Bytes FileHandler::getFirstBytes(const size_t num) const {
         // the set encryption file does not exist on the system
         throw std::runtime_error("file cannot be opened");
     }
-    Bytes b(num);                                                            // creates a buffer to hold the read bytes
+    Bytes b(num);                   // creates a buffer to hold the read bytes
     if (!readData(file, b, num)) {  // reads into the buffer
         // not enough characters to read (file is not long enough)
         throw std::length_error("File contains to few characters");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -79,7 +79,7 @@ bool isValidNumber(const std::string& number, const bool accept_blank, const u_i
 }
 
 bool readData(std::istream& stream, Bytes& data, const unsigned int& size) noexcept {
-    if(data.getMaxLen() - data.getLen() < size) {
+    if (data.getMaxLen() - data.getLen() < size) {
         PLOG_WARNING << "data object is smaller than the given size";
         return false;
     }
@@ -87,15 +87,15 @@ bool readData(std::istream& stream, Bytes& data, const unsigned int& size) noexc
     while (true) {
         // read the data until the given size is reached
         read += stream.readsome(reinterpret_cast<char*>(data.getBytes() + data.getLen() + read), size - read);
-        if(read != size && (stream.eof() || stream.peek() == EOF)){
+        if (read != size && (stream.eof() || stream.peek() == EOF)) {
             PLOG_WARNING << "end of file reached before the given size was read";
             return false;
         }
-        if(read == size){
+        if (read == size) {
             data.setLen(data.getLen() + read);
             return true;
         }
-        if(stream.fail() || stream.bad()){
+        if (stream.fail() || stream.bad()) {
             PLOG_WARNING << "failed to read data from stream";
             return false;
         }
@@ -107,14 +107,14 @@ bool readData(std::istream& stream, unsigned char* data, const unsigned int& siz
     while (true) {
         // read the data until the given size is reached
         read += stream.readsome(reinterpret_cast<char*>(data + read), size - read);
-        if(read != size && (stream.eof() || stream.peek() == EOF)){
+        if (read != size && (stream.eof() || stream.peek() == EOF)) {
             PLOG_WARNING << "end of file reached before the given size was read";
             return false;
         }
-        if(read == size){
+        if (read == size) {
             return true;
         }
-        if(stream.fail() || stream.bad()){
+        if (stream.fail() || stream.bad()) {
             PLOG_WARNING << "failed to read data from stream";
             return false;
         }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -77,3 +77,46 @@ bool isValidNumber(const std::string& number, const bool accept_blank, const u_i
     }
     return false;  // given number is not in the valid number bounds
 }
+
+bool readData(std::istream& stream, Bytes& data, const unsigned int& size) noexcept {
+    if(data.getMaxLen() - data.getLen() < size) {
+        PLOG_WARNING << "data object is smaller than the given size";
+        return false;
+    }
+    std::streamsize read = 0;
+    while (true) {
+        // read the data until the given size is reached
+        read += stream.readsome(reinterpret_cast<char*>(data.getBytes() + data.getLen() + read), size - read);
+        if(read != size && (stream.eof() || stream.peek() == EOF)){
+            PLOG_WARNING << "end of file reached before the given size was read";
+            return false;
+        }
+        if(read == size){
+            data.setLen(data.getLen() + read);
+            return true;
+        }
+        if(stream.fail() || stream.bad()){
+            PLOG_WARNING << "failed to read data from stream";
+            return false;
+        }
+    }
+}
+
+bool readData(std::istream& stream, unsigned char* data, const unsigned int& size) noexcept {
+    std::streamsize read = 0;
+    while (true) {
+        // read the data until the given size is reached
+        read += stream.readsome(reinterpret_cast<char*>(data + read), size - read);
+        if(read != size && (stream.eof() || stream.peek() == EOF)){
+            PLOG_WARNING << "end of file reached before the given size was read";
+            return false;
+        }
+        if(read == size){
+            return true;
+        }
+        if(stream.fail() || stream.bad()){
+            PLOG_WARNING << "failed to read data from stream";
+            return false;
+        }
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,14 @@ target_link_libraries(pman_test_chainhashdata gtest_main)
 target_link_libraries(pman_test_chainhashdata ${OPENSSL_LIBRARIES} pthread)
 target_include_directories(pman_test_chainhashdata PUBLIC ${INCLUDE_DIR})
 
+add_executable(pman_test_filehandler main_test.cpp filehandler_unittest.cpp ${SRC_DIR}/filehandler.cpp 
+    ${SRC_DIR}/chainhash_data.cpp ${SRC_DIR}/bytes.cpp ${SRC_DIR}/dataheader.cpp ${SRC_DIR}/file_modes.cpp ${SRC_DIR}/hash_modes.cpp
+    ${SRC_DIR}/format.cpp ${SRC_DIR}/chainhash_modes.cpp ${SRC_DIR}/pwfunc.cpp ${SRC_DIR}/utility.cpp ${SRC_DIR}/rng.cpp
+    ${SRC_DIR}/timer.cpp ${SRC_DIR}/sha256.cpp ${SRC_DIR}/sha384.cpp ${SRC_DIR}/sha512.cpp)
+target_link_libraries(pman_test_filehandler gtest_main)
+target_link_libraries(pman_test_filehandler ${OPENSSL_LIBRARIES} pthread)
+target_include_directories(pman_test_filehandler PUBLIC ${INCLUDE_DIR})
+
 add_test(bytes pman_test_bytes)
 add_test(block_opt pman_test_block)
 add_test(sha256 pman_test_sha256)
@@ -110,3 +118,4 @@ add_test(dataheader pman_test_dataheader)
 add_test(timer pman_test_timer)
 add_test(format pman_test_format)
 add_test(chainhashdata pman_test_chainhashdata)
+add_test(filehandler pman_test_filehandler)

--- a/tests/dataheader_generator.h
+++ b/tests/dataheader_generator.h
@@ -1,0 +1,94 @@
+#include "dataheader.h"
+#include "rng.h"
+
+struct DataHeaderGenSet{
+    std::optional<HModes> hashmode;
+    std::optional<unsigned char> datablocknum;
+    std::optional<unsigned char> decdatablocknum;
+    std::optional<unsigned char> chainhashlen1;
+    std::optional<unsigned char> chainhashlen2;
+};
+
+class DataHeaderGen{
+private:
+    static unsigned char getChainHashMode(unsigned char datablocklen){
+        unsigned char cm = -1;
+        while(true){
+            cm = RNG::get_random_byte(1, MAX_CHAINHASHMODE_NUMBER);  // chain hash mode
+            if(datablocklen == 0){
+                if(!(cm == CHAINHASH_NORMAL || cm == CHAINHASH_CONSTANT_SALT))
+                    continue;
+                else 
+                    break;
+            }else if(datablocklen < 8)
+                cm = CHAINHASH_CONSTANT_SALT;
+            if(datablocklen != 8 && cm == CHAINHASH_COUNT_SALT)
+                continue;
+            if(datablocklen != 32 && cm == CHAINHASH_QUADRATIC)
+                continue;
+            if(datablocklen != 0 && cm == CHAINHASH_NORMAL)
+                continue;
+            break;
+        }
+        return cm;
+    }
+public:
+    static Bytes generateDH(DataHeaderGenSet set = DataHeaderGenSet()){
+        Bytes ret(16); // length of file and header
+        ret.fillrandom(); // set in the end
+        ret.addSize(3);
+        ret.addByte(1); // file mode
+        unsigned char hashmode = set.hashmode.has_value() ? set.hashmode.value() : RNG::get_random_byte(1, MAX_HASHMODE_NUMBER); // hash mode
+        ret.addByte(hashmode);
+        unsigned char datablocknum = set.datablocknum.has_value() ? set.datablocknum.value() : RNG::get_random_byte();
+        ret.addByte(datablocknum); // number of datablocks
+        for(u_int16_t i = 0; i < datablocknum; i++){
+            unsigned char len = RNG::get_random_byte(1);
+            ret.addSize(len + 2);
+            ret.addByte(RNG::get_random_byte()); // datablock type
+            ret.addByte(len); // datablock length
+            Bytes tmp(len);
+            tmp.fillrandom();
+            tmp.addcopyToBytes(ret);
+        }
+        ret.addSize(9);
+        unsigned char clen1 = set.chainhashlen1.has_value() ? set.chainhashlen1.value() : RNG::get_random_byte();
+        ret.addByte(DataHeaderGen::getChainHashMode(clen1));   // chain hash mode
+        for(int i = 0; i < 5; i++)
+            ret.addByte(0);
+        ret.fillrandom();   //iterations
+        Bytes tmp2(clen1);
+        tmp2.fillrandom();
+        ret.addSize(clen1 + 10);
+        ret.addByte(clen1);
+        tmp2.addcopyToBytes(ret);
+
+        unsigned char clen2 = set.chainhashlen2.has_value() ? set.chainhashlen2.value() : RNG::get_random_byte();
+        ret.addByte(DataHeaderGen::getChainHashMode(clen2));   // chain hash mode
+        for(int i = 0; i < 5; i++)
+            ret.addByte(0);
+        ret.fillrandom();   //iterations
+
+        Bytes tmp3(clen2);
+        tmp3.fillrandom();
+        ret.addSize(clen2 + 1 + 1 + 2*HashModes::getHash(HModes(hashmode))->getHashSize());
+        ret.addByte(clen2);
+        tmp3.addcopyToBytes(ret);
+        ret.addrandom(ret.getMaxLen() - ret.getLen() - 1);
+        unsigned char ddatablocknum = set.decdatablocknum.has_value() ? set.decdatablocknum.value() : RNG::get_random_byte();
+        ret.addByte(ddatablocknum); // number of dec datablocks
+        for(u_int16_t i = 0; i < ddatablocknum; i++){
+            unsigned char len = RNG::get_random_byte(1);
+            ret.addSize(len + 2);
+            ret.addByte(RNG::get_random_byte()); // datablock type
+            ret.addByte(len); // datablock length
+            Bytes tmp(len);
+            tmp.fillrandom();
+            tmp.addcopyToBytes(ret);
+        }
+        Bytes len = Bytes::fromLong(ret.getLen(), true);
+        std::memcpy(ret.getBytes(), len.getBytes(), len.getLen());
+        std::memcpy(ret.getBytes() + 8, len.getBytes(), len.getLen());
+        return ret;
+    }
+};

--- a/tests/dataheader_generator.h
+++ b/tests/dataheader_generator.h
@@ -78,11 +78,10 @@ public:
         unsigned char ddatablocknum = set.decdatablocknum.has_value() ? set.decdatablocknum.value() : RNG::get_random_byte();
         ret.addByte(ddatablocknum); // number of dec datablocks
         for(u_int16_t i = 0; i < ddatablocknum; i++){
-            unsigned char len = RNG::get_random_byte(1);
-            ret.addSize(len + 2);
-            ret.addByte(RNG::get_random_byte()); // datablock type
-            ret.addByte(len); // datablock length
-            Bytes tmp(len);
+            ret.addSize(257);
+            ret.addByte(RNG::get_random_byte()); // enc datablock type
+            ret.addByte(RNG::get_random_byte()); // enc datablock length
+            Bytes tmp(255);
             tmp.fillrandom();
             tmp.addcopyToBytes(ret);
         }

--- a/tests/dataheader_unittest.cpp
+++ b/tests/dataheader_unittest.cpp
@@ -139,7 +139,7 @@ TEST(DataHeaderClass, setChainHash) {
             EXPECT_NO_THROW(dh2.setChainHash1(chainhash));
             // tests on the changed object
             EXPECT_THROW(dh2.getDataHeaderParts(), std::logic_error);                  // dataheader is not completed
-            EXPECT_EQ(22 + 2 * hash_size + 2 * chd->getLen(), dh2.getHeaderLength());  // both chainhashes are set, therefore a length can be computed
+            EXPECT_EQ(40 + 2 * hash_size + 2 * chd->getLen(), dh2.getHeaderLength());  // both chainhashes are set, therefore a length can be computed
             EXPECT_THROW(dh2.getHeaderBytes(), std::logic_error);                      // dataheader is not completed
             EXPECT_THROW(dh2.calcHeaderBytes(hsb), std::logic_error);                  // dataheader is not completed
             // some edge cases
@@ -277,6 +277,9 @@ TEST(DataHeaderClass, calcHeaderBytes) {
 
             // valid password hash validator and valid passwordhash
             EXPECT_NO_THROW(dh.setValidPasswordHashBytes(pval));
+            EXPECT_THROW(dh.calcHeaderBytes(phash), std::logic_error);
+
+            EXPECT_NO_THROW(dh.setFileSize(100000));
             EXPECT_EQ(typeid(void), typeid(dh.calcHeaderBytes(phash)));
             EXPECT_NO_THROW(dh.calcHeaderBytes(phash));
 
@@ -289,10 +292,10 @@ TEST(DataHeaderClass, calcHeaderBytes) {
             EXPECT_THROW(dh4.getHeaderBytes(), std::logic_error);                                    // dataheader is invalid
             EXPECT_NO_THROW(dataheaderbytes = dh.getHeaderBytes());                                  // dataheader is valid
             EXPECT_NO_THROW(dp = dh.getDataHeaderParts());                                           // dataheader is valid
-            EXPECT_EQ(22 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh.getHeaderLength());   // chainhashes are set, therefore length can be computed
-            EXPECT_EQ(22 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh2.getHeaderLength());  // chainhashes are set, therefore length can be computed
-            EXPECT_EQ(22 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh3.getHeaderLength());  // chainhashes are set, therefore length can be computed
-            EXPECT_EQ(22 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh4.getHeaderLength());  // chainhashes are set, therefore length can be computed
+            EXPECT_EQ(40 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh.getHeaderLength());   // chainhashes are set, therefore length can be computed
+            EXPECT_EQ(40 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh2.getHeaderLength());  // chainhashes are set, therefore length can be computed
+            EXPECT_EQ(40 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh3.getHeaderLength());  // chainhashes are set, therefore length can be computed
+            EXPECT_EQ(40 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dh4.getHeaderLength());  // chainhashes are set, therefore length can be computed
 
             // testing the returned dataparts
             EXPECT_EQ(HModes(hash_mode), dp.getHashMode());
@@ -308,19 +311,23 @@ TEST(DataHeaderClass, calcHeaderBytes) {
             EXPECT_EQ(pval, dp.getValidPasswordHash());
 
             // testing the returned dataheaderbytes
-            EXPECT_EQ(22 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dataheaderbytes.getLen());
-            EXPECT_EQ(file_mode, FModes(dataheaderbytes.copySubBytes(0, 1).getBytes()[0]));
-            EXPECT_EQ(hash_mode, HModes(dataheaderbytes.copySubBytes(1, 2).getBytes()[0]));
-            EXPECT_EQ(ch1_mode, CHModes(dataheaderbytes.copySubBytes(2, 3).getBytes()[0]));
-            EXPECT_EQ(iters1, dataheaderbytes.copySubBytes(3, 11).toLong());
-            EXPECT_EQ(chd1->getLen(), dataheaderbytes.copySubBytes(11, 12).getBytes()[0]);
-            EXPECT_EQ(chd1->getDataBlock(), dataheaderbytes.copySubBytes(12, 12 + chd1->getLen()));
-            EXPECT_EQ(ch2_mode, CHModes(dataheaderbytes.copySubBytes(12 + chd1->getLen(), 13 + chd1->getLen()).getBytes()[0]));
-            EXPECT_EQ(iters2, dataheaderbytes.copySubBytes(13 + chd1->getLen(), 21 + chd1->getLen()).toLong());
-            EXPECT_EQ(chd2->getLen(), dataheaderbytes.copySubBytes(21 + chd1->getLen(), 22 + chd1->getLen()).getBytes()[0]);
-            EXPECT_EQ(chd2->getDataBlock(), dataheaderbytes.copySubBytes(22 + chd1->getLen(), 22 + chd1->getLen() + chd2->getLen()));
-            EXPECT_EQ(pval, dataheaderbytes.copySubBytes(22 + chd1->getLen() + chd2->getLen(), 22 + chd1->getLen() + chd2->getLen() + hash_size));
-            EXPECT_EQ(dp.getEncSalt(), dataheaderbytes.copySubBytes(22 + chd1->getLen() + chd2->getLen() + hash_size, 22 + chd1->getLen() + chd2->getLen() + 2 * hash_size));
+            EXPECT_EQ(40 + 2 * hash_size + chd1->getLen() + chd2->getLen(), dataheaderbytes.getLen());
+            EXPECT_EQ(100000, dataheaderbytes.copySubBytes(0, 8).toLong());
+            EXPECT_EQ(dataheaderbytes.getLen(), dataheaderbytes.copySubBytes(8, 16).toLong());
+            EXPECT_EQ(file_mode, FModes(dataheaderbytes.copySubBytes(16, 17).getBytes()[0]));
+            EXPECT_EQ(hash_mode, HModes(dataheaderbytes.copySubBytes(17, 18).getBytes()[0]));
+            EXPECT_EQ(0, dataheaderbytes.copySubBytes(18, 19).getBytes()[0]);
+            EXPECT_EQ(ch1_mode, CHModes(dataheaderbytes.copySubBytes(19, 20).getBytes()[0]));
+            EXPECT_EQ(iters1, dataheaderbytes.copySubBytes(20, 28).toLong());
+            EXPECT_EQ(chd1->getLen(), dataheaderbytes.copySubBytes(28, 29).getBytes()[0]);
+            EXPECT_EQ(chd1->getDataBlock(), dataheaderbytes.copySubBytes(29, 29 + chd1->getLen()));
+            EXPECT_EQ(ch2_mode, CHModes(dataheaderbytes.copySubBytes(29 + chd1->getLen(), 30 + chd1->getLen()).getBytes()[0]));
+            EXPECT_EQ(iters2, dataheaderbytes.copySubBytes(30 + chd1->getLen(), 38 + chd1->getLen()).toLong());
+            EXPECT_EQ(chd2->getLen(), dataheaderbytes.copySubBytes(38 + chd1->getLen(), 39 + chd1->getLen()).getBytes()[0]);
+            EXPECT_EQ(chd2->getDataBlock(), dataheaderbytes.copySubBytes(39 + chd1->getLen(), 39 + chd1->getLen() + chd2->getLen()));
+            EXPECT_EQ(pval, dataheaderbytes.copySubBytes(39 + chd1->getLen() + chd2->getLen(), 39 + chd1->getLen() + chd2->getLen() + hash_size));
+            EXPECT_EQ(dp.getEncSalt(), dataheaderbytes.copySubBytes(39 + chd1->getLen() + chd2->getLen() + hash_size, 39 + chd1->getLen() + chd2->getLen() + 2 * hash_size));
+            EXPECT_EQ(0, dataheaderbytes.copySubBytes(39 + chd1->getLen() + chd2->getLen() + 2 * hash_size, 40 + chd1->getLen() + chd2->getLen() + 2 * hash_size).getBytes()[0]);
 
             // testing some edge cases
             // setting all data except valid hash or file mode

--- a/tests/dataheader_unittest.cpp
+++ b/tests/dataheader_unittest.cpp
@@ -345,17 +345,17 @@ TEST(DataHeaderClass, calcHeaderBytes) {
     }
 }
 
-TEST(DataHeaderClass, datablocks){
-    for(int k = 0; k < 100; k++){
+TEST(DataHeaderClass, datablocks) {
+    for (int k = 0; k < 100; k++) {
         std::vector<DataBlock> db;
         std::vector<EncDataBlock> ddb;
         HModes hashmode = HModes(RNG::get_random_byte(1, MAX_HASHMODE_NUMBER));
-        for(int i = 0; i < RNG::get_random_byte(); i++){
+        for (int i = 0; i < RNG::get_random_byte(); i++) {
             Bytes tmp(RNG::get_random_byte(1));
             tmp.fillrandom();
             db.push_back(DataBlock(DatablockType(RNG::get_random_byte()), tmp));
         }
-        for(int j = 0; j < RNG::get_random_byte(); j++){
+        for (int j = 0; j < RNG::get_random_byte(); j++) {
             Bytes tmp(255);
             tmp.fillrandom();
             ddb.push_back(EncDataBlock::createEncBlock(DatablockType(RNG::get_random_byte()), tmp, RNG::get_random_byte()));
@@ -368,10 +368,10 @@ TEST(DataHeaderClass, datablocks){
             .chainhashlen2 = 0,
         });
         std::unique_ptr<DataHeader> dh = DataHeader::setHeaderBytes(dhb).returnMove();
-        for(int i = 0; i < db.size(); i++){
+        for (int i = 0; i < db.size(); i++) {
             dh->addDataBlock(db[i]);
         }
-        for(int i = 0; i < ddb.size(); i++){
+        for (int i = 0; i < ddb.size(); i++) {
             dh->addEncDataBlock(ddb[i]);
         }
         dh->setFileSize(100000);

--- a/tests/dataheader_unittest.cpp
+++ b/tests/dataheader_unittest.cpp
@@ -282,7 +282,7 @@ TEST(DataHeaderClass, calcHeaderBytes) {
 
             // stores the valid data
             DataHeaderParts dp;
-            Bytes dataheaderbytes(MAX_HEADER_SIZE);
+            Bytes dataheaderbytes(0);
 
             EXPECT_THROW(dh2.getHeaderBytes(), std::logic_error);                                    // dataheader is invalid
             EXPECT_THROW(dh3.getHeaderBytes(), std::logic_error);                                    // dataheader is invalid

--- a/tests/filehandler_unittest.cpp
+++ b/tests/filehandler_unittest.cpp
@@ -1,0 +1,179 @@
+#include "filehandler.h"
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "rng.h"
+
+TEST(FileHandlerClass, statics){
+    EXPECT_EQ(FileHandler::extension, ".enc");
+    for(int i = 0; i < 10; i++){
+        std::filesystem::path path = RNG::get_random_string(10) + ".enc";
+        EXPECT_TRUE(FileHandler::isValidPath(path, false).returnValue());
+        EXPECT_TRUE(FileHandler::createFile(path).returnValue());
+        EXPECT_TRUE(FileHandler::isValidPath(path, true).returnValue());
+    }
+}
+
+TEST(FileHandlerClass, basic_empty){
+    // handling basic operations with an empty file
+    for(int i = 0; i < 10; i++){
+        Bytes tmp(10);
+        tmp.fillrandom();
+        std::filesystem::path path = RNG::get_random_string(10) + ".enc";
+        FileHandler::createFile(path);
+        FileHandler file_handler(path);
+        EXPECT_EQ(file_handler.getPath(), path);
+        EXPECT_TRUE(file_handler.isEmtpy());
+        EXPECT_TRUE(file_handler.getFileStream().is_open());
+        EXPECT_TRUE(file_handler.getDataStream().is_open());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 0);
+        EXPECT_THROW(file_handler.getFirstBytes(1), std::length_error);
+        
+        // write to file, check if it has been written correctly
+        EXPECT_TRUE(file_handler.writeBytesIfEmpty(tmp).returnValue());
+        EXPECT_FALSE(file_handler.isEmtpy());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 0);
+        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));
+        std::stringstream ss;
+        ss << file_handler.getFileStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        std::stringstream ss2;
+        ss2 << file_handler.getDataStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss2.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+
+        // cannot write to file if it is not empty
+        EXPECT_FALSE(file_handler.writeBytesIfEmpty(tmp).isSuccess());
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+
+        // update will lead to invalid dataheader (file size mismatch)
+        EXPECT_THROW(file_handler.update(), std::logic_error);
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 10);  // file size should be set anyway
+
+        // write to file, check if it has been written correctly
+        EXPECT_TRUE(file_handler.writeBytes(tmp).returnValue());
+        EXPECT_FALSE(file_handler.isEmtpy());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 0);  // file size should be reset
+        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));
+        std::stringstream ss3;
+        ss3 << file_handler.getFileStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss3.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        std::stringstream ss4;
+        ss4 << file_handler.getDataStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss4.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+
+        // cannot write to file if it is not empty
+        EXPECT_FALSE(file_handler.writeBytesIfEmpty(tmp).isSuccess());
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+
+        // update will lead to invalid dataheader (file size mismatch)
+        EXPECT_THROW(file_handler.update(), std::logic_error);
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 10);  // file size should be set anyway
+
+        EXPECT_FALSE(file_handler.getWriteStreamIfEmpty().isSuccess());
+
+        std::ofstream file = file_handler.getWriteStream().returnMove();
+        EXPECT_TRUE(file.is_open());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 0);  // file size should be reset
+        EXPECT_THROW(file_handler.getFirstBytes(1), std::length_error);
+        EXPECT_TRUE(file_handler.isEmtpy());
+
+        // write to file, check if it has been written correctly
+        file.write(reinterpret_cast<const char*>(tmp.getBytes()), tmp.getLen());
+        file.close();
+        EXPECT_FALSE(file_handler.isEmtpy());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 0);  // file size should be reset
+        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));
+        std::stringstream ss5;
+        ss5 << file_handler.getFileStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss5.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        std::stringstream ss6;
+        ss6 << file_handler.getDataStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss6.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+    }
+}
+
+TEST(FileHandlerClass, basic_filled){
+    for(int i = 0; i < 10; i++){
+        Bytes tmp(10);
+        tmp.fillrandom();
+        std::filesystem::path path = RNG::get_random_string(10) + ".enc";
+        FileHandler::createFile(path);
+        std::ofstream file(path, std::ios::binary);
+        file.write(reinterpret_cast<const char*>(tmp.getBytes()), tmp.getLen());
+        file.close();
+        FileHandler file_handler(path);
+        EXPECT_EQ(file_handler.getPath(), path);
+        EXPECT_FALSE(file_handler.isEmtpy());
+        EXPECT_TRUE(file_handler.getFileStream().is_open());
+        EXPECT_TRUE(file_handler.getDataStream().is_open());
+        EXPECT_EQ(file_handler.getHeaderSize(), 0);
+        EXPECT_EQ(file_handler.getFileSize(), 10);
+        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));
+        std::stringstream ss;
+        ss << file_handler.getFileStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        std::stringstream ss2;
+        ss2 << file_handler.getDataStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss2.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), 10);
+    }
+}
+
+TEST(FileHandlerClass, dataheader_simple){
+    for(int i = 0; i < 10; i++){
+        Bytes tmp(64);
+        tmp.fillrandom();
+        std::filesystem::path path = RNG::get_random_string(10) + ".enc";
+        FileHandler::createFile(path);
+        DataHeaderParts dhp;
+        dhp.setHashMode(HASHMODE_SHA512);
+        dhp.setFileDataMode(FILEMODE_PASSWORD);
+        dhp.setEncSalt(tmp);
+        dhp.setValidPasswordHash(tmp);
+        CHModes chm1 = CHAINHASH_CONSTANT_COUNT_SALT;
+        CHModes chm2 = CHAINHASH_QUADRATIC;
+        std::unique_ptr<ChainHashData> chd1 = std::make_unique<ChainHashData>(Format(CHAINHASH_CONSTANT_COUNT_SALT));
+        std::unique_ptr<ChainHashData> chd2 = std::make_unique<ChainHashData>(Format(CHAINHASH_QUADRATIC));
+        chd1->generateRandomData();
+        chd2->generateRandomData();
+        dhp.chainhash1 = ChainHash(chm1, 1000, std::move(chd1));
+        dhp.chainhash2 = ChainHash(chm2, 1000, std::move(chd2));
+        EXPECT_TRUE(dhp.isComplete(64));
+        std::unique_ptr<DataHeader> dh = DataHeader::setHeaderParts(dhp).returnMove();
+        dh->setFileSize(dh->getHeaderLength());
+        EXPECT_NO_THROW(dh->calcHeaderBytes());
+        FileHandler file_handler(path);
+        std::ofstream file = file_handler.getWriteStreamIfEmpty().returnMove();
+        file.write(reinterpret_cast<const char*>(dh->getHeaderBytes().getBytes()), dh->getHeaderBytes().getLen());
+        file.close();
+        EXPECT_NO_THROW(file_handler.update());
+        EXPECT_EQ(file_handler.getHeaderSize(), dh->getHeaderLength());
+        EXPECT_EQ(file_handler.getFileSize(), dh->getHeaderLength());
+        EXPECT_EQ(file_handler.getFirstBytes(1), dh->getHeaderBytes().copySubBytes(0, 1));
+        std::stringstream ss;
+        ss << file_handler.getFileStream().rdbuf();
+        EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss.str().c_str()), dh->getHeaderBytes().getBytes(), dh->getHeaderBytes().getLen()) == 0);
+        std::stringstream ss2;
+        ss2 << file_handler.getDataStream().rdbuf();
+        EXPECT_TRUE(ss2.str() == "");
+        EXPECT_EQ(file_handler.getAllBytes().getLen(), dh->getHeaderLength());
+        EXPECT_TRUE(file_handler.isDataHeader(FILEMODE_PASSWORD).returnValue());
+        EXPECT_TRUE(file_handler.getDataHeader().returnMove() == dh);
+    }
+}
+
+
+
+
+

--- a/tests/filehandler_unittest.cpp
+++ b/tests/filehandler_unittest.cpp
@@ -1,10 +1,10 @@
 #include "filehandler.h"
-#include "dataheader_generator.h"
 
 #include <gtest/gtest.h>
 
 #include <sstream>
 
+#include "dataheader_generator.h"
 #include "rng.h"
 
 TEST(FileHandlerClass, statics) {
@@ -38,10 +38,10 @@ TEST(FileHandlerClass, basic_empty) {
         file << tmp;
         file.close();
         // not updated yet
-        EXPECT_TRUE(file_handler.isEmtpy());    
+        EXPECT_TRUE(file_handler.isEmtpy());
         EXPECT_EQ(file_handler.getHeaderSize(), 0);
         EXPECT_EQ(file_handler.getFileSize(), 0);
-        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));   // that should work nethertheless
+        EXPECT_EQ(file_handler.getFirstBytes(1), tmp.copySubBytes(0, 1));  // that should work nethertheless
         std::stringstream ss;
         ss << file_handler.getFileStream().rdbuf();
         EXPECT_TRUE(std::memcmp(reinterpret_cast<const unsigned char*>(ss.str().c_str()), tmp.getBytes(), tmp.getLen()) == 0);
@@ -101,7 +101,6 @@ TEST(FileHandlerClass, basic_filled) {
         EXPECT_TRUE(dh->getHeaderBytes() == tmp);
         EXPECT_EQ(dh->getHeaderLength(), MIN_DATAHEADER_LEN);
         EXPECT_EQ(dh->getFileSize(), MIN_DATAHEADER_LEN);
-
     }
 }
 
@@ -182,7 +181,5 @@ TEST(FileHandlerClass, complex_filled) {
         EXPECT_TRUE(dh->getHeaderBytes() == tmp);
         EXPECT_EQ(dh->getHeaderLength(), file_handler.getHeaderSize());
         EXPECT_EQ(dh->getFileSize(), file_handler.getHeaderSize());
-
     }
 }
-

--- a/tests/filehandler_unittest.cpp
+++ b/tests/filehandler_unittest.cpp
@@ -1,13 +1,14 @@
 #include "filehandler.h"
 
 #include <gtest/gtest.h>
+
 #include <sstream>
 
 #include "rng.h"
 
-TEST(FileHandlerClass, statics){
+TEST(FileHandlerClass, statics) {
     EXPECT_EQ(FileHandler::extension, ".enc");
-    for(int i = 0; i < 10; i++){
+    for (int i = 0; i < 10; i++) {
         std::filesystem::path path = RNG::get_random_string(10) + ".enc";
         EXPECT_TRUE(FileHandler::isValidPath(path, false).returnValue());
         EXPECT_TRUE(FileHandler::createFile(path).returnValue());
@@ -15,9 +16,9 @@ TEST(FileHandlerClass, statics){
     }
 }
 
-TEST(FileHandlerClass, basic_empty){
+TEST(FileHandlerClass, basic_empty) {
     // handling basic operations with an empty file
-    for(int i = 0; i < 10; i++){
+    for (int i = 0; i < 10; i++) {
         Bytes tmp(10);
         tmp.fillrandom();
         std::filesystem::path path = RNG::get_random_string(10) + ".enc";
@@ -30,7 +31,7 @@ TEST(FileHandlerClass, basic_empty){
         EXPECT_EQ(file_handler.getHeaderSize(), 0);
         EXPECT_EQ(file_handler.getFileSize(), 0);
         EXPECT_THROW(file_handler.getFirstBytes(1), std::length_error);
-        
+
         // write to file, check if it has been written correctly
         EXPECT_TRUE(file_handler.writeBytesIfEmpty(tmp).returnValue());
         EXPECT_FALSE(file_handler.isEmtpy());
@@ -103,8 +104,8 @@ TEST(FileHandlerClass, basic_empty){
     }
 }
 
-TEST(FileHandlerClass, basic_filled){
-    for(int i = 0; i < 10; i++){
+TEST(FileHandlerClass, basic_filled) {
+    for (int i = 0; i < 10; i++) {
         Bytes tmp(10);
         tmp.fillrandom();
         std::filesystem::path path = RNG::get_random_string(10) + ".enc";
@@ -130,8 +131,8 @@ TEST(FileHandlerClass, basic_filled){
     }
 }
 
-TEST(FileHandlerClass, dataheader_simple){
-    for(int i = 0; i < 10; i++){
+TEST(FileHandlerClass, dataheader_simple) {
+    for (int i = 0; i < 10; i++) {
         Bytes tmp(64);
         tmp.fillrandom();
         std::filesystem::path path = RNG::get_random_string(10) + ".enc";
@@ -172,8 +173,3 @@ TEST(FileHandlerClass, dataheader_simple){
         EXPECT_TRUE(file_handler.getDataHeader().returnMove() == dh);
     }
 }
-
-
-
-
-

--- a/tests/main_test.cpp
+++ b/tests/main_test.cpp
@@ -5,10 +5,10 @@
 int main(int argc, char** argv) {
     // the main function that is running the tests
     // init logger
-    // static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
-    // // add file logger
-    // static plog::RollingFileAppender<plog::TxtFormatter> fileAppender("data/log.txt", 1024 * 1024 * 10, 3);
-    // plog::init(plog::verbose, &consoleAppender).addAppender(&fileAppender);
+    static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
+    // add file logger
+    static plog::RollingFileAppender<plog::TxtFormatter> fileAppender("data/log.txt", 1024 * 1024 * 10, 3);
+    plog::init(plog::verbose, &consoleAppender).addAppender(&fileAppender);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
the dataheader should be restructured to hold more important meta data

The first things that need to added are the file size in bytes and the header length in bytes for easier parsing
Also custom datablocks should be added
You can store any data in a datablock in the dataheader like the name, extension or creation date.
There should be two kinds of datablocks: one decrypted datablock (these should be at the beginning of the dataheader) and a encrypted (you need the password to read them)
